### PR TITLE
LCAM 582 C3 Fails to Initialise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 ### VS Code ###
 .vscode/
 *.java-version
+pgdata/

--- a/crown-court-contribution/docker-compose.yml
+++ b/crown-court-contribution/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - ~/apps/postgres:/var/lib/postgresql/data
+      - ./pgdata:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
       interval: 5s

--- a/crown-court-contribution/src/main/resources/application.yaml
+++ b/crown-court-contribution/src/main/resources/application.yaml
@@ -24,11 +24,9 @@ spring:
     change-log: classpath:/db/changelog/db.changelog-master.yaml
 
   jpa:
-    database-platform: org.hibernate.dialect.PostgreSQL10Dialect
-    show-sql: true
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    show-sql: false
     generate-ddl: false
-    hibernate:
-      ddl-auto: validate
     properties:
       hibernate.temp.use_jdbc_metadata_defaults: false
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-582)

C3 service was failing to initialise due to issues around using JPA to initialise the database. Changed config to fix this and applied other fixes noticed from related issues in laa-crime-evidence and laa-crown-court-proceedings.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
