### PR TITLE
LCAM-930|Update response with processActivity flag

### DIFF
--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/CalculateContributionService.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/CalculateContributionService.java
@@ -111,17 +111,19 @@ public class CalculateContributionService {
         return response;
     }
 
-    private Contribution verifyAndCreateContribs(CalculateContributionDTO calculateContributionDTO, String laaTransactionId,
-                                         boolean isReassessment, RepOrderDTO repOrderDTO,
-                                         CalculateContributionResponse response,
-                                         Contribution currentContribution) {
+    public Contribution verifyAndCreateContribs(final CalculateContributionDTO calculateContributionDTO,
+                                                final String laaTransactionId,
+                                                final boolean isReassessment,
+                                                final RepOrderDTO repOrderDTO,
+                                                final CalculateContributionResponse response,
+                                                final Contribution currentContribution) {
         TransferStatus currentTransferStatus = null;
         Integer currentContributionFileId = null;
 
         if (currentContribution != null) {
-             currentTransferStatus = currentContribution.getTransferStatus();
-             currentContributionFileId = currentContribution.getContributionFileId();
-        }   else {
+            currentTransferStatus = currentContribution.getTransferStatus();
+            currentContributionFileId = currentContribution.getContributionFileId();
+        } else {
             log.error("C3 Service: Current Contribution Is NULL.");
 
         }
@@ -143,7 +145,10 @@ public class CalculateContributionService {
         return null;
     }
 
-    private void requestEarlyTransfer(CalculateContributionDTO calculateContributionDTO, String laaTransactionId, CalculateContributionResponse response, Contribution currentContribution) {
+    public void requestEarlyTransfer(final CalculateContributionDTO calculateContributionDTO,
+                                     final String laaTransactionId,
+                                     final CalculateContributionResponse response,
+                                     final Contribution currentContribution) {
         Contribution latestSentContribution = maatCourtDataService.findLatestSentContribution(calculateContributionDTO.getRepId(), laaTransactionId);
         if (isEarlyTransferRequired(calculateContributionDTO, laaTransactionId, response, latestSentContribution) && currentContribution != null) {
             maatCourtDataService.updateContribution(new UpdateContributionRequest()
@@ -153,7 +158,7 @@ public class CalculateContributionService {
         }
     }
 
-    public Contribution getCurrentContribution(CalculateContributionDTO calculateContributionDTO, final String laaTransactionId){
+    public Contribution getCurrentContribution(final CalculateContributionDTO calculateContributionDTO, final String laaTransactionId) {
         final Integer contributionId = calculateContributionDTO.getId();
         List<Contribution> contributionsList = new ArrayList<>();
         if (contributionId != null) {
@@ -163,9 +168,9 @@ public class CalculateContributionService {
     }
 
     public boolean isCreateContributionRequired(final CalculateContributionDTO calculateContributionDTO,
-                                                 final boolean isReassessment,
-                                                 final RepOrderDTO repOrderDTO,
-                                                 final TransferStatus currentTransferStatus) {
+                                                final boolean isReassessment,
+                                                final RepOrderDTO repOrderDTO,
+                                                final TransferStatus currentTransferStatus) {
         return ((!TransferStatus.REQUESTED.equals(currentTransferStatus)
                 && (contributionService.hasApplicationStatusChanged(repOrderDTO, calculateContributionDTO.getCaseType(), calculateContributionDTO.getApplicationStatus())
                 || contributionService.hasCCOutcomeChanged(repOrderDTO.getId(), calculateContributionDTO.getLaaTransactionId())

--- a/crown-court-contribution/src/main/resources/schemas/CalculateContributionResponse.json
+++ b/crown-court-contribution/src/main/resources/schemas/CalculateContributionResponse.json
@@ -128,6 +128,10 @@
       "items": {
         "$ref": "common/ContributionSummary.json"
       }
+    },
+    "processActivity": {
+      "type": "boolean",
+      "description": "Indicator to call MATRIX process activity"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-930)

Update the calculate contribution response with a flag to indicate if the MATRIX process activity needs to be triggered to generate the correspondence after the calculate contribution call.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
