### PR TITLE
LCAM 879 fixed naming mistake with oauth secrets in environment template

### DIFF
--- a/helm_deploy/laa-crown-court-contribution/templates/_environment.tpl
+++ b/helm_deploy/laa-crown-court-contribution/templates/_environment.tpl
@@ -43,12 +43,12 @@ env:
   - name: MAAT_API_OAUTH_CLIENT_ID
     valueFrom:
         secretKeyRef:
-            name: hardship-api-oauth-client-id
+            name: maat-api-oauth-client-id
             key: MAAT_API_OAUTH_CLIENT_ID
   - name: MAAT_API_OAUTH_CLIENT_SECRET
     valueFrom:
         secretKeyRef:
-            name: hardship-api-oauth-client-secret
+            name: maat-api-oauth-client-secret
             key: MAAT_API_OAUTH_CLIENT_SECRET
   - name: HARDSHIP_API_OAUTH_CLIENT_ID
     valueFrom:


### PR DESCRIPTION
## What

Updated incorrect naming for secrets in environment template.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
