### PR TITLE
LCAM 1398 Contribution Variation Logic Defect Fix

### DIFF
--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionService.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionService.java
@@ -60,9 +60,10 @@ public class MaatCalculateContributionService {
     public static BigDecimal getAnnualDisposableIncome(final CalculateContributionDTO calculateContributionDTO) {
         if ((calculateContributionDTO.getDisposableIncomeAfterMagHardship() != null)) {
             return calculateContributionDTO.getDisposableIncomeAfterMagHardship();
+        } else if (calculateContributionDTO.getTotalAnnualDisposableIncome() != null){
+            return calculateContributionDTO.getTotalAnnualDisposableIncome();
         } else {
-            return calculateContributionDTO.getTotalAnnualDisposableIncome() != null
-                    ? calculateContributionDTO.getTotalAnnualDisposableIncome() : BigDecimal.ZERO;
+            return BigDecimal.ZERO;
         }
     }
 
@@ -287,8 +288,11 @@ public class MaatCalculateContributionService {
                             .add(calculateVariationAmount(calculateContributionDTO.getRepId(), contributionVariation.get()));
                 }
             } else {
-                annualDisposableIncome = calculateContributionDTO.getTotalAnnualDisposableIncome() != null
-                        ? calculateContributionDTO.getTotalAnnualDisposableIncome() : BigDecimal.ZERO;
+                if (calculateContributionDTO.getTotalAnnualDisposableIncome() != null) {
+                    annualDisposableIncome = calculateContributionDTO.getTotalAnnualDisposableIncome();
+                } else {
+                    annualDisposableIncome = BigDecimal.ZERO;
+                }
             }
         }
         return annualDisposableIncome;

--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionService.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionService.java
@@ -57,17 +57,13 @@ public class MaatCalculateContributionService {
                 calculateContributionDTO.getDateUpliftRemoved() == null;
     }
 
-    public static BigDecimal getAnnualDisposableIncome(final CalculateContributionDTO calculateContributionDTO, final BigDecimal annualDisposableIncome) {
-        if (annualDisposableIncome == null) {
-            if ((calculateContributionDTO.getDisposableIncomeAfterMagHardship() != null)) {
-                return calculateContributionDTO.getDisposableIncomeAfterMagHardship();
-            } else {
-                if (calculateContributionDTO.getTotalAnnualDisposableIncome() != null) {
-                    return calculateContributionDTO.getTotalAnnualDisposableIncome();
-                } else return BigDecimal.ZERO;
-            }
+    public static BigDecimal getAnnualDisposableIncome(final CalculateContributionDTO calculateContributionDTO) {
+        if ((calculateContributionDTO.getDisposableIncomeAfterMagHardship() != null)) {
+            return calculateContributionDTO.getDisposableIncomeAfterMagHardship();
+        } else {
+            return calculateContributionDTO.getTotalAnnualDisposableIncome() != null
+                    ? calculateContributionDTO.getTotalAnnualDisposableIncome() : BigDecimal.ZERO;
         }
-        return annualDisposableIncome;
     }
 
     public static String getEffectiveDateByNewWorkReason(final CalculateContributionDTO calculateContributionDTO,
@@ -280,20 +276,19 @@ public class MaatCalculateContributionService {
                                                       final CrownCourtOutcome crownCourtOutcome,
                                                       boolean isContributionRuleApplicable) {
         BigDecimal annualDisposableIncome = calculateContributionDTO.getDisposableIncomeAfterCrownHardship();
-        if (isContributionRuleApplicable) {
-            annualDisposableIncome = getAnnualDisposableIncome(calculateContributionDTO, annualDisposableIncome);
-            Optional<ContributionVariationDTO> contributionVariation = contributionRulesService.getContributionVariation(calculateContributionDTO.getCaseType(), calculateContributionDTO.getMagCourtOutcome(),
-                    crownCourtOutcome);
+        if (annualDisposableIncome == null) {
+            if (isContributionRuleApplicable) {
+                annualDisposableIncome = getAnnualDisposableIncome(calculateContributionDTO);
+                Optional<ContributionVariationDTO> contributionVariation = contributionRulesService.getContributionVariation(calculateContributionDTO.getCaseType(), calculateContributionDTO.getMagCourtOutcome(),
+                        crownCourtOutcome);
 
-            if (contributionVariation.isPresent()) {
-                annualDisposableIncome = annualDisposableIncome
-                        .add(calculateVariationAmount(calculateContributionDTO.getRepId(), contributionVariation.get()));
-            }
-        } else {
-            if (annualDisposableIncome == null) {
-                if (calculateContributionDTO.getTotalAnnualDisposableIncome() != null) {
-                    annualDisposableIncome = calculateContributionDTO.getTotalAnnualDisposableIncome();
-                } else annualDisposableIncome = BigDecimal.ZERO;
+                if (contributionVariation.isPresent()) {
+                    annualDisposableIncome = annualDisposableIncome
+                            .add(calculateVariationAmount(calculateContributionDTO.getRepId(), contributionVariation.get()));
+                }
+            } else {
+                annualDisposableIncome = calculateContributionDTO.getTotalAnnualDisposableIncome() != null
+                        ? calculateContributionDTO.getTotalAnnualDisposableIncome() : BigDecimal.ZERO;
             }
         }
         return annualDisposableIncome;


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-1398)

Reworked variation logic to avoid using the disposable income calculated after crown hardship if available as this was causing incorrect contributions being calculated when solicitors costs were added on top of this figure. Instead will use the disposable income calculated after mags hardship as this has the solicitors costs deducted.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
