### PR TITLE
LCAM 1459 IoJ Result Not Passed to Check Contribs Condition

### DIFF
--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/dto/RepOrderDTO.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/dto/RepOrderDTO.java
@@ -34,6 +34,7 @@ public class RepOrderDTO {
     private LocalDate sentenceOrderDate;
     private String evidenceFeeLevel;
     private String rorsStatus;
+    private String iojResult;
     @Builder.Default
     private List<PassportAssessmentDTO> passportAssessments = new ArrayList<>();
     @Builder.Default

--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/repository/CorrespondenceRuleRepository.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/repository/CorrespondenceRuleRepository.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Repository;
 import uk.gov.justice.laa.crime.contribution.entity.CorrespondenceRule;
 import uk.gov.justice.laa.crime.contribution.projection.CorrespondenceRuleAndTemplateInfo;
 
+import java.util.Optional;
+
 @Repository
 public interface CorrespondenceRuleRepository extends JpaRepository<CorrespondenceRule, Integer> {
 
@@ -16,11 +18,11 @@ public interface CorrespondenceRuleRepository extends JpaRepository<Corresponden
             "AND (R.MCOO_OUTCOME = :magsOutcome OR MCOO_OUTCOME = 'ANY' OR MCOO_OUTCOME = 'NONE' ) " +
             "AND (R.CCOO_OUTCOME = :ccSummaryOutcome OR    R.CCOO_OUTCOME = 'ANY' OR    R.CCOO_OUTCOME = 'NONE' ) " +
             "AND (INIT_RESULT  = 'ANY' OR INIT_RESULT  = :initResult );", nativeQuery = true)
-    CorrespondenceRuleAndTemplateInfo getCoteInfo(String meansResult,
-                                                  String iojResult,
-                                                  String magsOutcome,
-                                                  String ccSummaryOutcome,
-                                                  String initResult
+    Optional<CorrespondenceRuleAndTemplateInfo> getCoteInfo(String meansResult,
+                                                            String iojResult,
+                                                            String magsOutcome,
+                                                            String ccSummaryOutcome,
+                                                            String initResult
     );
 
 }

--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/ContributionService.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/ContributionService.java
@@ -139,7 +139,8 @@ public class ContributionService {
                 contributionRequestDTO.getIojResult(),
                 contributionRequestDTO.getMagCourtOutcome(),
                 contributionRequestDTO.getCrownCourtOutcome(),
-                contributionRequestDTO.getInitResult());
+                contributionRequestDTO.getInitResult()
+        ).orElse(null);
     }
 
     public boolean isCds15WorkAround(final RepOrderDTO repOrderDTO) {

--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionService.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionService.java
@@ -154,6 +154,7 @@ public class MaatCalculateContributionService {
         ContributionResponseDTO contributionResponseDTO = contributionService.checkContribsCondition(ContributionRequestDTO.builder()
                 .caseType(calculateContributionDTO.getCaseType())
                 .effectiveDate(calculateContributionDTO.getEffectiveDate())
+                .iojResult(repOrderDTO.getIojResult())
                 .monthlyContribs(calculateContributionDTO.getMonthlyContributions())
                 .fullResult(fullResult)
                 .initResult(initAssessment.map(assessment -> assessment.getResult().name()).orElse(null))

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/ContributionServiceTest.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/ContributionServiceTest.java
@@ -26,6 +26,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -522,7 +523,7 @@ class ContributionServiceTest {
             ContributionRequestDTO request) {
 
         when(repository.getCoteInfo(anyString(), anyString(), anyString(), anyString(), anyString()))
-                .thenReturn(TestModelDataBuilder.getCorrespondenceRuleAndTemplateInfo());
+                .thenReturn(Optional.of(TestModelDataBuilder.getCorrespondenceRuleAndTemplateInfo()));
 
         ContributionResponseDTO response = contributionService.checkContribsCondition(request);
 
@@ -546,7 +547,7 @@ class ContributionServiceTest {
             ContributionRequestDTO request) {
 
         when(repository.getCoteInfo(anyString(), anyString(), anyString(), anyString(), anyString()))
-                .thenReturn(TestModelDataBuilder.getCorrespondenceRuleAndTemplateInfo());
+                .thenReturn(Optional.of(TestModelDataBuilder.getCorrespondenceRuleAndTemplateInfo()));
 
         ContributionResponseDTO response = contributionService.checkContribsCondition(request);
 
@@ -572,7 +573,7 @@ class ContributionServiceTest {
             ContributionRequestDTO request) {
 
         when(repository.getCoteInfo(anyString(), anyString(), anyString(), anyString(), anyString()))
-                .thenReturn(TestModelDataBuilder.getEmptyCorrespondenceRuleAndTemplateInfo());
+                .thenReturn(Optional.of(TestModelDataBuilder.getEmptyCorrespondenceRuleAndTemplateInfo()));
 
         ContributionResponseDTO response = contributionService.checkContribsCondition(request);
 
@@ -582,6 +583,28 @@ class ContributionServiceTest {
                 .isEqualTo(1);
         softly.assertThat(response.getCorrespondenceType())
                 .isEmpty();
+    }
+
+    @Test
+    void givenAValidContributionRequest_whenCheckContribConditionIsInvoked_thenReturnNoContribution() {
+        ContributionRequestDTO request  = ContributionRequestDTO.builder()
+                .caseType(CaseType.INDICTABLE)
+                .initResult("FULL")
+                .fullResult("PASS")
+                .magCourtOutcome("SENT FOR TRIAL")
+                .crownCourtOutcome("")
+                .iojResult("PASS")
+                .build();
+
+        when(repository.getCoteInfo(anyString(), anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(Optional.empty());
+
+        ContributionResponseDTO response = contributionService.checkContribsCondition(request);
+
+        softly.assertThat(response.getDoContribs())
+                .isEqualTo("N");
+        softly.assertThat(response.getCalcContribs())
+                .isEqualTo("N");
     }
 
     @Test


### PR DESCRIPTION
[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-1459)

- Added IoJ result to the RepOrderDTO that is populated by call to MAAT API to find rep order. Also passed the IoJ result through to the checkContribsCondition method so it can be used to populate the sql query against the CORRESPONDENCE_RULES table.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
