### PR TITLE
Replace get contribution appeal amount call with new enum

### DIFF
--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/config/ServicesConfiguration.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/config/ServicesConfiguration.java
@@ -50,9 +50,6 @@ public class ServicesConfiguration {
             private String summaryUrl;
 
             @NotNull
-            private String getAppealAmountUrl;
-
-            @NotNull
             private String getRepOrderUrl;
 
             @NotNull

--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/AppealContributionService.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/AppealContributionService.java
@@ -13,6 +13,7 @@ import uk.gov.justice.laa.crime.contribution.model.Contribution;
 import uk.gov.justice.laa.crime.common.model.contribution.common.ApiAssessment;
 import uk.gov.justice.laa.crime.common.model.contribution.maat_api.CreateContributionRequest;
 import uk.gov.justice.laa.crime.common.model.contribution.maat_api.GetContributionAmountRequest;
+import uk.gov.justice.laa.crime.contribution.staticdata.enums.AppealContributionAmount;
 import uk.gov.justice.laa.crime.enums.AssessmentResult;
 import uk.gov.justice.laa.crime.enums.contribution.CurrentStatus;
 
@@ -43,11 +44,11 @@ public class AppealContributionService {
 
         GetContributionAmountRequest getContributionAmountRequest = getContributionAmountRequestMapper.map(calculateContributionDTO, assessmentResult);
         BigDecimal appealContributionAmount = null;
-        if(getContributionAmountRequest.getAppealType() != null
-                && getContributionAmountRequest.getCaseType() != null
-                && getContributionAmountRequest.getOutcome() != null &&
-                getContributionAmountRequest.getAssessmentResult() != null){
-             appealContributionAmount = maatCourtDataService.getContributionAppealAmount(getContributionAmountRequest);
+
+        if (getContributionAmountRequest.getOutcome() != null &&
+                getContributionAmountRequest.getAssessmentResult() != null) {
+            appealContributionAmount = AppealContributionAmount.calculate(getContributionAmountRequest.getAppealType(), getContributionAmountRequest.getOutcome(), getContributionAmountRequest.getAssessmentResult())
+                                                               .getContributionAmount();
         }
 
         Integer repId = calculateContributionDTO.getRepId();

--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/MaatCourtDataService.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/MaatCourtDataService.java
@@ -68,17 +68,6 @@ public class MaatCourtDataService {
         return response;
     }
 
-    public BigDecimal getContributionAppealAmount(GetContributionAmountRequest request) {
-        BigDecimal response = maatAPIClient.get(
-                new ParameterizedTypeReference<>() {
-                },
-                configuration.getMaatApi().getContributionEndpoints().getGetAppealAmountUrl(),
-                request.getCaseType(), request.getAppealType(), request.getOutcome(), request.getAssessmentResult()
-        );
-        log.info(RESPONSE_STRING, response);
-        return response;
-    }
-
     public CorrespondenceState findCorrespondenceState(Integer repId) {
         CorrespondenceState response = maatAPIClient.get(
                 new ParameterizedTypeReference<>() {

--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/staticdata/enums/AppealContributionAmount.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/staticdata/enums/AppealContributionAmount.java
@@ -1,0 +1,41 @@
+package uk.gov.justice.laa.crime.contribution.staticdata.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import uk.gov.justice.laa.crime.enums.AppealType;
+import uk.gov.justice.laa.crime.enums.AssessmentResult;
+import uk.gov.justice.laa.crime.enums.CrownCourtAppealOutcome;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor
+public enum AppealContributionAmount {
+
+    NO_CONTRIBUTION(new BigDecimal(0)),
+    PART_CONTRIBUTION(new BigDecimal(250)),
+    FULL_CONTRIBUTION(new BigDecimal(500));
+
+    private final BigDecimal contributionAmount;
+
+    public static AppealContributionAmount calculate(AppealType appealType, CrownCourtAppealOutcome appealOutcome, AssessmentResult assessmentResult) {
+        if (AssessmentResult.PASS.equals(assessmentResult)) {
+            return NO_CONTRIBUTION;
+        }
+
+        if (CrownCourtAppealOutcome.SUCCESSFUL.equals(appealOutcome)) {
+            return NO_CONTRIBUTION;
+        }
+
+        if ((AppealType.ACS.equals(appealType) && CrownCourtAppealOutcome.PART_SUCCESS.equals(appealOutcome))
+                || (AppealType.ASE.equals(appealType) && CrownCourtAppealOutcome.UNSUCCESSFUL.equals(appealOutcome))) {
+            return PART_CONTRIBUTION;
+        }
+
+        if (CrownCourtAppealOutcome.UNSUCCESSFUL.equals(appealOutcome)) {
+            return FULL_CONTRIBUTION;
+        }
+
+        return NO_CONTRIBUTION;
+    }
+}

--- a/crown-court-contribution/src/main/resources/application.yaml
+++ b/crown-court-contribution/src/main/resources/application.yaml
@@ -62,7 +62,6 @@ services:
       base-url: ${services.maat-api.assessments-domain}/contributions
       find-url: ${services.maat-api.contribution-endpoints.base-url}/{repId}
       summary-url: ${services.maat-api.assessments-domain}/contributions/{repId}/summary
-      get-appeal-amount-url: ${services.maat-api.assessments-domain}/contribution-appeal/caty-case-type/{caseType}/apty-code/{appealType}/cc-outcome/{outcome}/assessmentResult/{assessmentResult}
       get-rep-order-url: ${services.maat-api.assessments-domain}/rep-orders/{repId}
       contribs-parameters-url: ${services.maat-api.assessments-domain}/contribution-calc-params/{effectiveDate}
     correspondence-state-endpoints:

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/config/MockServicesConfiguration.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/config/MockServicesConfiguration.java
@@ -13,7 +13,6 @@ public class MockServicesConfiguration {
                         "/contributions",
                         "/contributions/{repId}",
                         "/contributions/{repId}/summary",
-                        "/contribution-appeal",
                         "/rep-orders/{repId}",
                         "/contribution-calc-params/{effectiveDate}"
                 );

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/controller/ContributionControllerContributionIntegrationTest.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/controller/ContributionControllerContributionIntegrationTest.java
@@ -74,9 +74,6 @@ class ContributionControllerContributionIntegrationTest {
     @Value("${services.maat-api.contribution-endpoints.summary-url}")
     private String summaryUrl;
 
-    @Value("${services.maat-api.contribution-endpoints.get-appeal-amount-url}")
-    private String getAppealAmountUrl;
-
     @Value("${services.maat-api.contribution-endpoints.find-url}")
     private String findContributionUrl;
 
@@ -125,21 +122,6 @@ class ContributionControllerContributionIntegrationTest {
                         WireMock.ok()
                                 .withHeader("Content-Type", String.valueOf(MediaType.APPLICATION_JSON))
                                 .withBody(objectMapper.writeValueAsString(TestModelDataBuilder.getRepOrderDTO()))
-                )
-        );
-
-        var appealAmountUrl = UriComponentsBuilder.fromUriString(getAppealAmountUrl).build(
-                appealContributionRequest.getCaseType(),
-                appealContributionRequest.getAppealType().getCode(),
-                appealContributionRequest.getLastOutcome().getOutcome().getValue(),
-                appealContributionRequest.getAssessments().get(0).getResult().toString()
-        );
-
-        wiremock.stubFor(get(appealAmountUrl.getPath())
-                .willReturn(
-                        WireMock.ok()
-                                .withHeader("Content-Type", String.valueOf(MediaType.APPLICATION_JSON))
-                                .withBody(objectMapper.writeValueAsString(BigDecimal.ZERO))
                 )
         );
 

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/enums/staticdata/AppealContributionAmountTest.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/enums/staticdata/AppealContributionAmountTest.java
@@ -1,0 +1,96 @@
+package uk.gov.justice.laa.crime.contribution.enums.staticdata;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.justice.laa.crime.contribution.staticdata.enums.AppealContributionAmount;
+import uk.gov.justice.laa.crime.enums.AppealType;
+import uk.gov.justice.laa.crime.enums.AssessmentResult;
+import uk.gov.justice.laa.crime.enums.CrownCourtAppealOutcome;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class AppealContributionAmountTest {
+    @ParameterizedTest
+    @MethodSource("appealTypeAndAppealOutcomeCombinations")
+    void givenASuccessfulAssessmentResult_thenZeroContributionAmountIsReturned(AppealType appealType, CrownCourtAppealOutcome appealOutcome) {
+        AppealContributionAmount result = AppealContributionAmount.calculate(appealType, appealOutcome, AssessmentResult.PASS);
+
+        assertThat(result).isEqualTo(AppealContributionAmount.NO_CONTRIBUTION);
+    }
+
+    @ParameterizedTest
+    @MethodSource("appealTypes")
+    void givenAFailedAssessmentResultAndSuccessfulAppealOutcome_thenZeroContributionAmountIsReturned(AppealType appealType) {
+        AppealContributionAmount result = AppealContributionAmount.calculate(appealType, CrownCourtAppealOutcome.SUCCESSFUL, AssessmentResult.FAIL);
+
+        assertThat(result).isEqualTo(AppealContributionAmount.NO_CONTRIBUTION);
+    }
+
+    @Test
+    void givenAppealTypeIsACNAndPartSuccessAppealOutcome_thenZeroCContributionIsReturned() {
+        AppealContributionAmount result = AppealContributionAmount.calculate(AppealType.ACN, CrownCourtAppealOutcome.PART_SUCCESS, AssessmentResult.FAIL);
+
+        assertThat(result).isEqualTo(AppealContributionAmount.NO_CONTRIBUTION);
+    }
+
+    @Test
+    void givenAppealTypeIsASEAndPartSuccessAppealOutcome_thenZeroCContributionIsReturned() {
+        AppealContributionAmount result = AppealContributionAmount.calculate(AppealType.ASE, CrownCourtAppealOutcome.PART_SUCCESS, AssessmentResult.FAIL);
+
+        assertThat(result).isEqualTo(AppealContributionAmount.NO_CONTRIBUTION);
+    }
+
+    @Test
+    void givenAppealTypeIsACSAndPartSuccessfulAppealOutcome_thenPartialContributionAmountIsReturned() {
+        AppealContributionAmount result = AppealContributionAmount.calculate(AppealType.ACS, CrownCourtAppealOutcome.PART_SUCCESS, AssessmentResult.FAIL);
+
+        assertThat(result).isEqualTo(AppealContributionAmount.PART_CONTRIBUTION);
+    }
+
+    @Test
+    void givenAppealTypeIsASEAndUnsuccessfulAppealOutcome_thenPartialContributionAmountIsReturned() {
+        AppealContributionAmount result = AppealContributionAmount.calculate(AppealType.ASE, CrownCourtAppealOutcome.UNSUCCESSFUL, AssessmentResult.FAIL);
+
+        assertThat(result).isEqualTo(AppealContributionAmount.PART_CONTRIBUTION);
+    }
+
+    @Test
+    void givenAppealTypeIsACNAndUnsuccessfulAppealOutcome_thenFullContributionAmountIsReturned() {
+        AppealContributionAmount result = AppealContributionAmount.calculate(AppealType.ACN, CrownCourtAppealOutcome.UNSUCCESSFUL, AssessmentResult.FAIL);
+
+        assertThat(result).isEqualTo(AppealContributionAmount.FULL_CONTRIBUTION);
+    }
+
+    @Test
+    void givenAppealTypeIsACSAndUnsuccessfulAppealOutcome_thenFullContributionAmountIsReturned() {
+        AppealContributionAmount result = AppealContributionAmount.calculate(AppealType.ACS, CrownCourtAppealOutcome.UNSUCCESSFUL, AssessmentResult.FAIL);
+
+        assertThat(result).isEqualTo(AppealContributionAmount.FULL_CONTRIBUTION);
+    }
+
+    private static Stream<Arguments> appealTypeAndAppealOutcomeCombinations() {
+        return Stream.of(
+                Arguments.arguments(AppealType.ACS, CrownCourtAppealOutcome.SUCCESSFUL),
+                Arguments.arguments(AppealType.ACS, CrownCourtAppealOutcome.PART_SUCCESS),
+                Arguments.arguments(AppealType.ACS, CrownCourtAppealOutcome.UNSUCCESSFUL),
+                Arguments.arguments(AppealType.ACN, CrownCourtAppealOutcome.SUCCESSFUL),
+                Arguments.arguments(AppealType.ACN, CrownCourtAppealOutcome.PART_SUCCESS),
+                Arguments.arguments(AppealType.ACN, CrownCourtAppealOutcome.UNSUCCESSFUL),
+                Arguments.arguments(AppealType.ASE, CrownCourtAppealOutcome.SUCCESSFUL),
+                Arguments.arguments(AppealType.ASE, CrownCourtAppealOutcome.PART_SUCCESS),
+                Arguments.arguments(AppealType.ASE, CrownCourtAppealOutcome.UNSUCCESSFUL)
+        );
+    }
+
+    private static Stream<Arguments> appealTypes() {
+        return Stream.of(
+                Arguments.arguments(AppealType.ACS),
+                Arguments.arguments(AppealType.ACN),
+                Arguments.arguments(AppealType.ASE)
+        );
+    }
+}

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/MaatCourtDataServiceTest.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/MaatCourtDataServiceTest.java
@@ -72,27 +72,6 @@ class MaatCourtDataServiceTest {
     }
 
     @Test
-    void givenValidParams_whenGetContributionAppealAmountIsInvoked_thenResponseIsReturned() {
-        GetContributionAmountRequest expected = new GetContributionAmountRequest()
-                .withCaseType(CaseType.APPEAL_CC)
-                .withAppealType(AppealType.ACN)
-                .withOutcome(CrownCourtAppealOutcome.SUCCESSFUL)
-                .withAssessmentResult(AssessmentResult.PASS);
-
-        maatCourtDataService.getContributionAppealAmount(expected);
-
-        verify(maatCourtDataClient).get(
-                eq(new ParameterizedTypeReference<BigDecimal>() {
-                }),
-                anyString(),
-                any(CaseType.class),
-                any(AppealType.class),
-                any(CrownCourtAppealOutcome.class),
-                any(AssessmentResult.class)
-        );
-    }
-
-    @Test
     void givenValidRepId_whenFindCorrespondenceStateIsInvoked_thenResponseIsReturned() {
         maatCourtDataService.findCorrespondenceState(TEST_REP_ID);
         verify(maatCourtDataClient).get(eq(new ParameterizedTypeReference<CorrespondenceState>() {

--- a/crown-court-contribution/src/test/resources/application.yaml
+++ b/crown-court-contribution/src/test/resources/application.yaml
@@ -58,7 +58,6 @@ services:
       base-url: ${services.maat-api.assessments-domain}/contributions
       find-url: ${services.maat-api.contribution-endpoints.base-url}/{repId}
       summary-url: ${services.maat-api.assessments-domain}/contributions/{repId}/summary
-      get-appeal-amount-url: ${services.maat-api.assessments-domain}/contribution-appeal/caty-case-type/{caseType}/apty-code/{appealType}/cc-outcome/{outcome}/assessmentResult/{assessmentResult}
       get-rep-order-url: ${services.maat-api.assessments-domain}/rep-orders/{repId}
       contribs-parameters-url: ${services.maat-api.assessments-domain}/contribution-calc-params/{effectiveDate}
     correspondence-state-endpoints:


### PR DESCRIPTION
This PR adds a new _AppealContributionAmount_ enum and a static method for calculating the appeal contribution amount based on the appeal type, Crown Court appeal outcome and appeal assessment result, and uses it in the _AppealContributionService_ to calculate the appeal contribution amount without needing to call the MAAT Court Data API  to look-up what is otherwise static data (from the appeal contribution rules db table).

This PR also removes the `getContributionAppealAmount` method from the _MaatCourtDataService_. This method was previously used to calculate the appeal contribution amount in the _AppealContributionService_, however this has now been replaced by the new _AppealContributionAmount_ enum.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1448)

