### PR TITLE
LCAM 1588 Remove Correspondence Status Logic

### DIFF
--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/config/ServicesConfiguration.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/config/ServicesConfiguration.java
@@ -30,9 +30,6 @@ public class ServicesConfiguration {
         private ContributionEndpoints contributionEndpoints;
 
         @NotNull
-        private CorrespondenceStateEndpoints correspondenceStateEndpoints;
-
-        @NotNull
         private RepOrderEndpoints repOrderEndpoints;
 
         @Data
@@ -54,14 +51,6 @@ public class ServicesConfiguration {
 
             @NotNull
             private String contribsParametersUrl;
-        }
-
-        @Data
-        @NoArgsConstructor
-        @AllArgsConstructor
-        public static class CorrespondenceStateEndpoints {
-            @NotNull
-            private String baseUrl;
         }
 
         @Data

--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/CompareContributionService.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/CompareContributionService.java
@@ -48,10 +48,8 @@ public class CompareContributionService {
 
     private int getResultOnNoPreviousContribution(RepOrderDTO repOrderDTO, int repId) {
         if (isCaseTypeAppealCC(repOrderDTO)) {
-            setCorrespondenceStatus(repId, CorrespondenceStatus.APPEAL_CC);
         }
         if (isCds15WorkAround(repOrderDTO)) {
-            setCorrespondenceStatus(repId, CorrespondenceStatus.CDS15);
         }
         return 0;
     }
@@ -81,7 +79,6 @@ public class CompareContributionService {
         MagCourtOutcome magCourtOutcome = calculateContributionDTO.getMagCourtOutcome();
         String magsOutcome = magCourtOutcome == null ? null : magCourtOutcome.getOutcome();
         if (magCourtOutcomeHasChangedOrCaseTypeAndCorrespondenceStatusIsApealCC(repOrderDTO, status, magsOutcome)) {
-            setCorrespondenceStatus(repId, CorrespondenceStatus.APPEAL_CC);
             return 1;
         }
         return getResultOnAppealToCCOrCds15WorkAroundOrReassessment(repOrderDTO, repId, status);
@@ -90,7 +87,6 @@ public class CompareContributionService {
     private int getResultOnAppealToCCOrCds15WorkAroundOrReassessment(RepOrderDTO repOrderDTO, int repId,
                                                                      CorrespondenceStatus status) {
         if (isStatusAppealCC(status)) {
-            setCorrespondenceStatus(repId, CorrespondenceStatus.NONE);
             return 2;
         }
         return getResultOnCds15EWorkAroundOrReassessment(repOrderDTO, repId, status);
@@ -108,10 +104,8 @@ public class CompareContributionService {
     private int getResultOnCds15WorkAround(int repId, CorrespondenceStatus status) {
         int result = 2;
         if (isStatusCds15(status)) {
-            setCorrespondenceStatus(repId, CorrespondenceStatus.NONE);
         } else if (isStatusReass(status)) {
             result = 1;
-            setCorrespondenceStatus(repId, CorrespondenceStatus.CDS15);
         }
         return result;
     }
@@ -134,10 +128,6 @@ public class CompareContributionService {
 
     private static boolean isStatusReass(CorrespondenceStatus status) {
         return CorrespondenceStatus.REASS.getStatus().equals(status.getStatus());
-    }
-
-    private void setCorrespondenceStatus(int repId, CorrespondenceStatus status) {
-        maatCourtDataService.updateCorrespondenceState(repId, status);
     }
 
     private boolean magCourtOutcomeHasChangedOrCaseTypeAndCorrespondenceStatusIsApealCC(RepOrderDTO repOrderDTO,

--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionService.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionService.java
@@ -275,7 +275,7 @@ public class MaatCalculateContributionService {
     public Contribution createContributions(final CalculateContributionDTO calculateContributionDTO,
                                             ContributionResult result) {
         log.info("Inactivate existing Contribution and create a new Contribution");
-        if (compareContributionService.compareContribution(calculateContributionDTO, result) < 2) {
+        if (compareContributionService.shouldCreateContribution(calculateContributionDTO, result)) {
             CreateContributionRequest createContributionRequest =
                     createContributionRequestMapper.map(calculateContributionDTO, result);
             return maatCourtDataService.createContribution(createContributionRequest);

--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/MaatCourtDataService.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/MaatCourtDataService.java
@@ -13,7 +13,6 @@ import uk.gov.justice.laa.crime.contribution.dto.ContributionsSummaryDTO;
 import uk.gov.justice.laa.crime.contribution.dto.RepOrderCCOutcomeDTO;
 import uk.gov.justice.laa.crime.contribution.dto.RepOrderDTO;
 import uk.gov.justice.laa.crime.contribution.model.Contribution;
-import uk.gov.justice.laa.crime.enums.contribution.CorrespondenceStatus;
 
 import java.util.List;
 import java.util.Map;
@@ -47,44 +46,6 @@ public class MaatCourtDataService {
                 },
                 configuration.getMaatApi().getContributionEndpoints().getBaseUrl(),
                 Map.of()
-        );
-        log.info(RESPONSE_STRING, response);
-        return response;
-    }
-
-    public CorrespondenceStatus findCorrespondenceState(int repId) {
-        CorrespondenceStatus response = maatAPIClient.get(
-
-                new ParameterizedTypeReference<>() {
-                },
-                configuration.getMaatApi().getCorrespondenceStateEndpoints().getBaseUrl(),
-                repId
-        );
-        log.info(RESPONSE_STRING, response);
-        return response;
-    }
-
-    public CorrespondenceStatus createCorrespondenceState(int repId, CorrespondenceStatus state) {
-        CorrespondenceStatus response = maatAPIClient.post(
-                state,
-                new ParameterizedTypeReference<>() {
-                },
-                configuration.getMaatApi().getCorrespondenceStateEndpoints().getBaseUrl(),
-                Map.of(),
-                repId
-        );
-        log.info(RESPONSE_STRING, response);
-        return response;
-    }
-
-    public CorrespondenceStatus updateCorrespondenceState(int repId, CorrespondenceStatus state) {
-        CorrespondenceStatus response = maatAPIClient.put(
-                state,
-                new ParameterizedTypeReference<>() {
-                },
-                configuration.getMaatApi().getCorrespondenceStateEndpoints().getBaseUrl(),
-                Map.of(),
-                repId
         );
         log.info(RESPONSE_STRING, response);
         return response;

--- a/crown-court-contribution/src/main/resources/application.yaml
+++ b/crown-court-contribution/src/main/resources/application.yaml
@@ -70,8 +70,6 @@ services:
       summary-url: ${services.maat-api.assessments-domain}/contributions/{repId}/summary
       get-rep-order-url: ${services.maat-api.assessments-domain}/rep-orders/{repId}
       contribs-parameters-url: ${services.maat-api.assessments-domain}/contribution-calc-params/{effectiveDate}
-    correspondence-state-endpoints:
-      base-url: ${services.maat-api.assessments-domain}/rep-orders/{repId}/correspondence-state
     rep-order-endpoints:
       find-outcome-url: ${services.maat-api.assessments-domain}/rep-orders/cc-outcome/reporder/{repId}
   hardship-api:

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/config/MockServicesConfiguration.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/config/MockServicesConfiguration.java
@@ -17,11 +17,6 @@ public class MockServicesConfiguration {
                         "/contribution-calc-params/{effectiveDate}"
                 );
 
-        ServicesConfiguration.MaatApi.CorrespondenceStateEndpoints correspondenceStateEndpoints =
-                new ServicesConfiguration.MaatApi.CorrespondenceStateEndpoints(
-                        "rep-orders/{repId}/correspondence-state"
-                );
-
         ServicesConfiguration.MaatApi.RepOrderEndpoints repOrderEndpoints =
                 new ServicesConfiguration.MaatApi.RepOrderEndpoints("/rep-orders/cc-outcome/reporder/{repId}");
 
@@ -32,7 +27,6 @@ public class MockServicesConfiguration {
         maatApiConfiguration.setBaseUrl(host);
         servicesConfiguration.setMaatApi(maatApiConfiguration);
         maatApiConfiguration.setContributionEndpoints(contributionEndpoints);
-        maatApiConfiguration.setCorrespondenceStateEndpoints(correspondenceStateEndpoints);
         maatApiConfiguration.setRepOrderEndpoints(repOrderEndpoints);
 
         hardshipApiConfiguration.setBaseUrl(host);

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/CompareContributionServiceTest.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/CompareContributionServiceTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.contribution.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.contribution.dto.CalculateContributionDTO;
+import uk.gov.justice.laa.crime.contribution.model.Contribution;
 import uk.gov.justice.laa.crime.contribution.model.ContributionResult;
 import uk.gov.justice.laa.crime.enums.CaseType;
 import uk.gov.justice.laa.crime.enums.MagCourtOutcome;
@@ -33,9 +34,7 @@ class CompareContributionServiceTest {
     private ContributionService contributionService;
 
     @Test
-    void givenNoPreviousContributionAndCaseTypeIsAppealCC_whenCompareContributionServiceIsInvoked_thenReturnZero() {
-        when(maatCourtDataService.findContribution(anyInt(), anyBoolean()))
-                .thenReturn(List.of());
+    void givenNoPreviousContribution_whenShouldCreateContributionIsInvoked_thenReturnTrue() {
         CalculateContributionDTO calculateContributionDTO =
                 TestModelDataBuilder.getContributionDTOForCompareContributionService(
                         CaseType.APPEAL_CC.getCaseTypeString(),
@@ -46,45 +45,19 @@ class CompareContributionServiceTest {
                         null
                 );
         ContributionResult contributionResult = TestModelDataBuilder.getContributionResult();
+        Contribution InactiveContribution = TestModelDataBuilder.buildContributionForCompareContributionService();
+        InactiveContribution.setActive("N");
 
-        int result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
+        when(maatCourtDataService.findContribution(anyInt(), anyBoolean()))
+                .thenReturn(List.of(InactiveContribution));
 
-        assertThat(result).isZero();
-        verify(maatCourtDataService, times(1))
-                .updateCorrespondenceState(anyInt(), eq(CorrespondenceStatus.APPEAL_CC));
+        boolean result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
+
+        assertThat(result).isTrue();
     }
 
     @Test
-    void givenNoPreviousContributionAndCds15WorkAroundIsTrue_whenCompareContributionServiceIsInvoked_thenReturnZero() {
-        when(maatCourtDataService.findContribution(anyInt(), anyBoolean()))
-                .thenReturn(List.of());
-        when(contributionService.isCds15WorkAround(any()))
-                .thenReturn(true);
-        CalculateContributionDTO calculateContributionDTO =
-                TestModelDataBuilder.getContributionDTOForCompareContributionService(
-                        CaseType.COMMITAL.getCaseTypeString(),
-                        null,
-                        null,
-                        null,
-                        null,
-                        null
-                );
-        ContributionResult contributionResult = TestModelDataBuilder.getContributionResult();
-
-        int result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
-
-        assertThat(result).isZero();
-        verify(maatCourtDataService, times(1))
-                .updateCorrespondenceState(anyInt(), eq(CorrespondenceStatus.CDS15));
-    }
-
-    @Test
-    void givenActiveNotIdenticalContribution_whenCompareContributionServiceIsInvoked_thenReturnOne() {
-        when(maatCourtDataService.findContribution(anyInt(), anyBoolean()))
-                .thenReturn(List.of(
-                                TestModelDataBuilder.buildContributionForCompareContributionService()
-                        )
-                );
+    void givenActiveNotIdenticalContribution_whenShouldCreateContributionIsInvoked_thenReturnTrue() {
         CalculateContributionDTO calculateContributionDTO =
                 TestModelDataBuilder.getContributionDTOForCompareContributionService(
                         CaseType.COMMITAL.getCaseTypeString(),
@@ -105,22 +78,19 @@ class CompareContributionServiceTest {
                 .effectiveDate(LocalDate.now())
                 .build();
 
-        int result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
-
-        assertThat(result).isOne();
-        verify(maatCourtDataService, times(0))
-                .updateCorrespondenceState(anyInt(), any(CorrespondenceStatus.class));
-    }
-
-    @Test
-    void givenActiveIdenticalContributionAndHasMagCourtOutcome_whenCompareContributionServiceIsInvoked_thenReturnOne() {
         when(maatCourtDataService.findContribution(anyInt(), anyBoolean()))
                 .thenReturn(List.of(
                                 TestModelDataBuilder.buildContributionForCompareContributionService()
                         )
                 );
-        when(contributionService.hasMessageOutcomeChanged(anyString(), any()))
-                .thenReturn(true);
+
+        boolean result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void givenActiveIdenticalContributionAndMagsOutcomeChanged_whenShouldCreateContributionIsInvoked_thenReturnTrue() {
         CalculateContributionDTO calculateContributionDTO =
                 TestModelDataBuilder.getContributionDTOForCompareContributionService(
                         CaseType.COMMITAL.getCaseTypeString(),
@@ -132,24 +102,21 @@ class CompareContributionServiceTest {
                 );
         ContributionResult contributionResult = TestModelDataBuilder.getContributionResult();
 
-        int result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
-
-        assertThat(result).isOne();
-        verify(maatCourtDataService, times(1))
-                .updateCorrespondenceState(anyInt(), eq(CorrespondenceStatus.APPEAL_CC));
-    }
-
-    @Test
-    void givenActiveIdenticalContributionWithCaseTypeAndCorrespondenceStatusAppealCC_whenCompareContributionServiceIsInvoked_thenReturnOne() {
         when(maatCourtDataService.findContribution(anyInt(), anyBoolean()))
                 .thenReturn(List.of(
                                 TestModelDataBuilder.buildContributionForCompareContributionService()
                         )
                 );
-        when(maatCourtDataService.findCorrespondenceState(anyInt())).
-                thenReturn(CorrespondenceStatus.APPEAL_CC);
         when(contributionService.hasMessageOutcomeChanged(anyString(), any()))
-                .thenReturn(false);
+                .thenReturn(true);
+
+        boolean result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void givenActiveIdenticalContributionWithCaseTypeAppealCC_whenShouldCreateContributionIsInvoked_thenReturnTrue() {
         CalculateContributionDTO calculateContributionDTO =
                 TestModelDataBuilder.getContributionDTOForCompareContributionService(
                         CaseType.APPEAL_CC.getCaseTypeString(),
@@ -161,24 +128,21 @@ class CompareContributionServiceTest {
                 );
         ContributionResult contributionResult = TestModelDataBuilder.getContributionResult();
 
-        int result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
-
-        assertThat(result).isOne();
-        verify(maatCourtDataService, times(1))
-                .updateCorrespondenceState(anyInt(), eq(CorrespondenceStatus.APPEAL_CC));
-    }
-
-    @Test
-    void givenActiveIdenticalContributionWithCorrespondenceStatusAppealCC_whenCompareContributionServiceIsInvoked_thenReturnTwo() {
         when(maatCourtDataService.findContribution(anyInt(), anyBoolean()))
                 .thenReturn(List.of(
                                 TestModelDataBuilder.buildContributionForCompareContributionService()
                         )
                 );
-        when(maatCourtDataService.findCorrespondenceState(anyInt())).
-                thenReturn(CorrespondenceStatus.APPEAL_CC);
         when(contributionService.hasMessageOutcomeChanged(anyString(), any()))
                 .thenReturn(false);
+
+        boolean result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void givenActiveIdenticalContributionNonAppealCCWithoutMagsOutcomeChange_whenShouldCreateContributionIsInvoked_thenReturnFalse() {
         CalculateContributionDTO calculateContributionDTO =
                 TestModelDataBuilder.getContributionDTOForCompareContributionService(
                         CaseType.COMMITAL.getCaseTypeString(),
@@ -190,73 +154,16 @@ class CompareContributionServiceTest {
                 );
         ContributionResult contributionResult = TestModelDataBuilder.getContributionResult();
 
-        int result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
-
-        assertThat(result).isEqualTo(2);
-        verify(maatCourtDataService, times(1))
-                .updateCorrespondenceState(anyInt(), eq(CorrespondenceStatus.NONE));
-    }
-
-    @Test
-    void givenActiveIdenticalContributionForCds15WorkAroundAndCorrespondenceStatusCds15_whenCompareContributionServiceIsInvoked_thenReturnTwo() {
         when(maatCourtDataService.findContribution(anyInt(), anyBoolean()))
                 .thenReturn(List.of(
                                 TestModelDataBuilder.buildContributionForCompareContributionService()
                         )
                 );
-        when(maatCourtDataService.findCorrespondenceState(anyInt()))
-                .thenReturn(CorrespondenceStatus.CDS15);
         when(contributionService.hasMessageOutcomeChanged(anyString(), any()))
                 .thenReturn(false);
-        when(contributionService.isCds15WorkAround(any()))
-                .thenReturn(true);
-        CalculateContributionDTO calculateContributionDTO =
-                TestModelDataBuilder.getContributionDTOForCompareContributionService(
-                        CaseType.COMMITAL.getCaseTypeString(),
-                        BigDecimal.valueOf(250),
-                        BigDecimal.valueOf(250),
-                        BigDecimal.valueOf(250),
-                        LocalDate.now(),
-                        MagCourtOutcome.APPEAL_TO_CC
-                );
-        ContributionResult contributionResult = TestModelDataBuilder.getContributionResult();
 
-        int result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
+        boolean result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
 
-        assertThat(result).isEqualTo(2);
-        verify(maatCourtDataService, times(1))
-                .updateCorrespondenceState(anyInt(), eq(CorrespondenceStatus.NONE));
+        assertThat(result).isFalse();
     }
-
-    @Test
-    void givenActiveIdenticalContributionForCds15WorkAroundAndCorrespondenceStatusReass_whenCompareContributionServiceIsInvoked_thenReturnOne() {
-        when(maatCourtDataService.findContribution(anyInt(), anyBoolean()))
-                .thenReturn(List.of(
-                                TestModelDataBuilder.buildContributionForCompareContributionService()
-                        )
-                );
-        when(maatCourtDataService.findCorrespondenceState(anyInt()))
-                .thenReturn(CorrespondenceStatus.REASS);
-        when(contributionService.hasMessageOutcomeChanged(anyString(), any()))
-                .thenReturn(false);
-        when(contributionService.isCds15WorkAround(any()))
-                .thenReturn(true);
-        CalculateContributionDTO calculateContributionDTO =
-                TestModelDataBuilder.getContributionDTOForCompareContributionService(
-                        CaseType.COMMITAL.getCaseTypeString(),
-                        BigDecimal.valueOf(250),
-                        BigDecimal.valueOf(250),
-                        BigDecimal.valueOf(250),
-                        LocalDate.now(),
-                        MagCourtOutcome.APPEAL_TO_CC
-                );
-        ContributionResult contributionResult = TestModelDataBuilder.getContributionResult();
-
-        int result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
-
-        assertThat(result).isOne();
-        verify(maatCourtDataService, times(1))
-                .updateCorrespondenceState(anyInt(), eq(CorrespondenceStatus.CDS15));
-    }
-
 }

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/CompareContributionServiceTest.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/CompareContributionServiceTest.java
@@ -11,14 +11,12 @@ import uk.gov.justice.laa.crime.contribution.model.Contribution;
 import uk.gov.justice.laa.crime.contribution.model.ContributionResult;
 import uk.gov.justice.laa.crime.enums.CaseType;
 import uk.gov.justice.laa.crime.enums.MagCourtOutcome;
-import uk.gov.justice.laa.crime.enums.contribution.CorrespondenceStatus;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -45,11 +43,11 @@ class CompareContributionServiceTest {
                         null
                 );
         ContributionResult contributionResult = TestModelDataBuilder.getContributionResult();
-        Contribution InactiveContribution = TestModelDataBuilder.buildContributionForCompareContributionService();
-        InactiveContribution.setActive("N");
+        Contribution inactiveContribution = TestModelDataBuilder.buildContributionForCompareContributionService();
+        inactiveContribution.setActive("N");
 
         when(maatCourtDataService.findContribution(anyInt(), anyBoolean()))
-                .thenReturn(List.of(InactiveContribution));
+                .thenReturn(List.of(inactiveContribution));
 
         boolean result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
 

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/CompareContributionServiceTest.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/CompareContributionServiceTest.java
@@ -47,7 +47,7 @@ class CompareContributionServiceTest {
                 );
         ContributionResult contributionResult = TestModelDataBuilder.getContributionResult();
 
-        int result = compareContributionService.compareContribution(calculateContributionDTO, contributionResult);
+        int result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
 
         assertThat(result).isZero();
         verify(maatCourtDataService, times(1))
@@ -71,7 +71,7 @@ class CompareContributionServiceTest {
                 );
         ContributionResult contributionResult = TestModelDataBuilder.getContributionResult();
 
-        int result = compareContributionService.compareContribution(calculateContributionDTO, contributionResult);
+        int result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
 
         assertThat(result).isZero();
         verify(maatCourtDataService, times(1))
@@ -105,7 +105,7 @@ class CompareContributionServiceTest {
                 .effectiveDate(LocalDate.now())
                 .build();
 
-        int result = compareContributionService.compareContribution(calculateContributionDTO, contributionResult);
+        int result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
 
         assertThat(result).isOne();
         verify(maatCourtDataService, times(0))
@@ -132,7 +132,7 @@ class CompareContributionServiceTest {
                 );
         ContributionResult contributionResult = TestModelDataBuilder.getContributionResult();
 
-        int result = compareContributionService.compareContribution(calculateContributionDTO, contributionResult);
+        int result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
 
         assertThat(result).isOne();
         verify(maatCourtDataService, times(1))
@@ -161,7 +161,7 @@ class CompareContributionServiceTest {
                 );
         ContributionResult contributionResult = TestModelDataBuilder.getContributionResult();
 
-        int result = compareContributionService.compareContribution(calculateContributionDTO, contributionResult);
+        int result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
 
         assertThat(result).isOne();
         verify(maatCourtDataService, times(1))
@@ -190,7 +190,7 @@ class CompareContributionServiceTest {
                 );
         ContributionResult contributionResult = TestModelDataBuilder.getContributionResult();
 
-        int result = compareContributionService.compareContribution(calculateContributionDTO, contributionResult);
+        int result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
 
         assertThat(result).isEqualTo(2);
         verify(maatCourtDataService, times(1))
@@ -221,7 +221,7 @@ class CompareContributionServiceTest {
                 );
         ContributionResult contributionResult = TestModelDataBuilder.getContributionResult();
 
-        int result = compareContributionService.compareContribution(calculateContributionDTO, contributionResult);
+        int result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
 
         assertThat(result).isEqualTo(2);
         verify(maatCourtDataService, times(1))
@@ -252,7 +252,7 @@ class CompareContributionServiceTest {
                 );
         ContributionResult contributionResult = TestModelDataBuilder.getContributionResult();
 
-        int result = compareContributionService.compareContribution(calculateContributionDTO, contributionResult);
+        int result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
 
         assertThat(result).isOne();
         verify(maatCourtDataService, times(1))

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionServiceTest.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionServiceTest.java
@@ -117,7 +117,7 @@ class MaatCalculateContributionServiceTest {
 
     @Test
     void givenValidContributionAndCompareResultIsLessThanTwo_whenCreateContributionsIsInvoked_thenContributionIsReturn() {
-        when(compareContributionService.compareContribution(
+        when(compareContributionService.shouldCreateContribution(
                 any(CalculateContributionDTO.class), any(ContributionResult.class))
         ).thenReturn(1);
 
@@ -132,7 +132,7 @@ class MaatCalculateContributionServiceTest {
 
     @Test
     void givenValidContributionAndCompareResultIsGreaterThanTwo_whenCreateContributionsIsInvoked_thenNullIsReturn() {
-        when(compareContributionService.compareContribution(
+        when(compareContributionService.shouldCreateContribution(
                 any(CalculateContributionDTO.class), any(ContributionResult.class))
         ).thenReturn(3);
         Contribution result = maatCalculateContributionService.createContributions(
@@ -1045,7 +1045,7 @@ class MaatCalculateContributionServiceTest {
                         .withMonthlyContributions(BigDecimal.TEN)
                 );
 
-        when(compareContributionService.compareContribution(
+        when(compareContributionService.shouldCreateContribution(
                 any(CalculateContributionDTO.class), any(ContributionResult.class))
         ).thenReturn(2);
 
@@ -1094,7 +1094,7 @@ class MaatCalculateContributionServiceTest {
         ContributionResult contributionResult = TestModelDataBuilder.getContributionResult();
         Contribution contribution = TestModelDataBuilder.getContribution();
 
-        when(compareContributionService.compareContribution(any(CalculateContributionDTO.class), any(ContributionResult.class)))
+        when(compareContributionService.shouldCreateContribution(any(CalculateContributionDTO.class), any(ContributionResult.class)))
                 .thenReturn(1);
         when(contributionRequestMapper.map(any(CalculateContributionDTO.class), any(ContributionResult.class)))
                 .thenReturn(new CreateContributionRequest());

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionServiceTest.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionServiceTest.java
@@ -116,7 +116,7 @@ class MaatCalculateContributionServiceTest {
     }
 
     @Test
-    void givenValidContributionAndShouldCreateIsTrue_whenCreateContributionsIsInvoked_thenContributionIsReturn() {
+    void givenValidContributionAndShouldCreateContributionIsTrue_whenCreateContributionsIsInvoked_thenContributionIsReturned() {
         when(compareContributionService.shouldCreateContribution(
                 any(CalculateContributionDTO.class), any(ContributionResult.class))
         ).thenReturn(true);
@@ -135,7 +135,7 @@ class MaatCalculateContributionServiceTest {
     }
 
     @Test
-    void givenValidContributionAndShouldCreateIsFalse_whenCreateContributionsIsInvoked_thenNullIsReturn() {
+    void givenValidContributionAndShouldCreateContributionIsFalse_whenCreateContributionsIsInvoked_thenNullIsReturned() {
         when(compareContributionService.shouldCreateContribution(
                 any(CalculateContributionDTO.class), any(ContributionResult.class))
         ).thenReturn(false);

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionServiceTest.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionServiceTest.java
@@ -116,28 +116,33 @@ class MaatCalculateContributionServiceTest {
     }
 
     @Test
-    void givenValidContributionAndCompareResultIsLessThanTwo_whenCreateContributionsIsInvoked_thenContributionIsReturn() {
+    void givenValidContributionAndShouldCreateIsTrue_whenCreateContributionsIsInvoked_thenContributionIsReturn() {
         when(compareContributionService.shouldCreateContribution(
                 any(CalculateContributionDTO.class), any(ContributionResult.class))
-        ).thenReturn(1);
-
+        ).thenReturn(true);
         when(maatCourtDataService.createContribution(any()))
                 .thenReturn(TestModelDataBuilder.getContribution());
 
         Contribution result = maatCalculateContributionService.createContributions(new CalculateContributionDTO(),
                 ContributionResult.builder().build()
         );
+
+        verify(maatCourtDataService, times(1))
+                .createContribution(any(CreateContributionRequest.class));
         assertThat(result).isNotNull();
     }
 
     @Test
-    void givenValidContributionAndCompareResultIsGreaterThanTwo_whenCreateContributionsIsInvoked_thenNullIsReturn() {
+    void givenValidContributionAndShouldCreateIsFalse_whenCreateContributionsIsInvoked_thenNullIsReturn() {
         when(compareContributionService.shouldCreateContribution(
                 any(CalculateContributionDTO.class), any(ContributionResult.class))
-        ).thenReturn(3);
+        ).thenReturn(false);
+
         Contribution result = maatCalculateContributionService.createContributions(
                 new CalculateContributionDTO(), ContributionResult.builder().build()
         );
+
+        verifyNoInteractions(maatCourtDataService);
         assertThat(result).isNull();
     }
 
@@ -1047,7 +1052,7 @@ class MaatCalculateContributionServiceTest {
 
         when(compareContributionService.shouldCreateContribution(
                 any(CalculateContributionDTO.class), any(ContributionResult.class))
-        ).thenReturn(2);
+        ).thenReturn(false);
 
         when(maatCourtDataService.getContributionCalcParameters(anyString()))
                 .thenReturn(ContributionCalcParametersDTO.builder()
@@ -1095,7 +1100,7 @@ class MaatCalculateContributionServiceTest {
         Contribution contribution = TestModelDataBuilder.getContribution();
 
         when(compareContributionService.shouldCreateContribution(any(CalculateContributionDTO.class), any(ContributionResult.class)))
-                .thenReturn(1);
+                .thenReturn(true);
         when(contributionRequestMapper.map(any(CalculateContributionDTO.class), any(ContributionResult.class)))
                 .thenReturn(new CreateContributionRequest());
         when(maatCourtDataService.createContribution(any(CreateContributionRequest.class)))

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionServiceTest.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionServiceTest.java
@@ -122,6 +122,8 @@ class MaatCalculateContributionServiceTest {
         ).thenReturn(true);
         when(maatCourtDataService.createContribution(any()))
                 .thenReturn(TestModelDataBuilder.getContribution());
+        when(contributionRequestMapper.map(any(CalculateContributionDTO.class), any(ContributionResult.class)))
+                .thenReturn(new CreateContributionRequest());
 
         Contribution result = maatCalculateContributionService.createContributions(new CalculateContributionDTO(),
                 ContributionResult.builder().build()

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/MaatCourtDataServiceTest.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/MaatCourtDataServiceTest.java
@@ -17,7 +17,6 @@ import uk.gov.justice.laa.crime.contribution.dto.ContributionsSummaryDTO;
 import uk.gov.justice.laa.crime.contribution.dto.RepOrderCCOutcomeDTO;
 import uk.gov.justice.laa.crime.contribution.dto.RepOrderDTO;
 import uk.gov.justice.laa.crime.contribution.model.Contribution;
-import uk.gov.justice.laa.crime.enums.contribution.CorrespondenceStatus;
 
 import java.util.List;
 
@@ -56,35 +55,6 @@ class MaatCourtDataServiceTest {
         verify(maatCourtDataClient).post(
                 any(CreateContributionRequest.class), eq(new ParameterizedTypeReference<Contribution>() {
                 }), anyString(), anyMap()
-        );
-    }
-
-    @Test
-    void givenValidRepId_whenFindCorrespondenceStateIsInvoked_thenResponseIsReturned() {
-        maatCourtDataService.findCorrespondenceState(TEST_REP_ID);
-        verify(maatCourtDataClient).get(eq(new ParameterizedTypeReference<CorrespondenceStatus>() {
-        }), anyString(), anyInt());
-    }
-
-    @Test
-    void givenValidParams_whenCreateCorrespondenceStateIsInvoked_thenResponseIsReturned() {
-        maatCourtDataService.createCorrespondenceState(TEST_REP_ID, CorrespondenceStatus.APPEAL_CC);
-        verify(maatCourtDataClient).post(
-                any(CorrespondenceStatus.class), eq(new ParameterizedTypeReference<CorrespondenceStatus>() {
-                }), anyString(), anyMap(), anyInt()
-        );
-    }
-
-    @Test
-    void givenValidParams_whenUpdateCorrespondenceStateIsInvoked_thenResponseIsReturned() {
-        maatCourtDataService.updateCorrespondenceState(TEST_REP_ID, CorrespondenceStatus.NONE);
-        verify(maatCourtDataClient).put(
-                any(CorrespondenceStatus.class),
-                eq(new ParameterizedTypeReference<CorrespondenceStatus>() {
-                }),
-                anyString(),
-                anyMap(),
-                anyInt()
         );
     }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-1588)

- Reworked compare contribution service to no longer check or update the correspondence state as now this logic is in a separate service this is redundant.
- Removed the calls to get, create and update correspondence state from maat api and associated config.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.