### PR TITLE
Fix contribution effective date calculations

### DIFF
--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/builder/ContributionDTOBuilder.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/builder/ContributionDTOBuilder.java
@@ -22,8 +22,15 @@ public class ContributionDTOBuilder {
                 .repId(request.getRepId())
                 .effectiveDate(DateUtil.parseLocalDate(request.getEffectiveDate()))
                 .contributionCap(request.getContributionCap())
-                .monthlyContributions(request.getMonthlyContributions() !=null ? request.getMonthlyContributions() : BigDecimal.ZERO)
-                .upfrontContributions(request.getUpfrontContributions() !=null ? request.getUpfrontContributions() : BigDecimal.ZERO)
+
+                // Do not default to zero if getMonthlyContributions() returns null, as the nullness
+                // of this field is used to determine if the CalculateContributionDTO instance
+                // represents a real contribution (where monthly contributions is not null) or an
+                // initialised but empty object (where monthly contributions is null and therefore
+                // represents no actual contribution).
+                .monthlyContributions(request.getMonthlyContributions())
+
+                .upfrontContributions(request.getUpfrontContributions() != null ? request.getUpfrontContributions() : BigDecimal.ZERO)
                 .dateUpliftApplied(DateUtil.parseLocalDate(request.getDateUpliftApplied()))
                 .dateUpliftRemoved(DateUtil.parseLocalDate(request.getDateUpliftRemoved()))
                 .caseType(request.getCaseType())

--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionService.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionService.java
@@ -81,7 +81,8 @@ public class MaatCalculateContributionService {
         if (NewWorkReason.FMA == newWorkReason) {
             return assEffectiveDate.toString();
         } else if (NewWorkReason.PAI == newWorkReason) {
-            if (calculateContributionDTO.getMonthlyContributions().compareTo(monthlyContributions) <= 0) {
+            if (calculateContributionDTO.getMonthlyContributions() != null
+                && calculateContributionDTO.getMonthlyContributions().compareTo(monthlyContributions) <= 0) {
                 return calculateContributionDTO.getEffectiveDate().toString();
             } else {
                 return assEffectiveDate.toString();
@@ -246,7 +247,8 @@ public class MaatCalculateContributionService {
     }
 
     private boolean shouldCreateContributions(ContributionResult result, CalculateContributionDTO calculateContributionDTO) {
-        return (result.monthlyAmount() != null && result.monthlyAmount().compareTo(calculateContributionDTO.getMonthlyContributions()) != 0)
+        return (result.monthlyAmount() != null && calculateContributionDTO.getMonthlyContributions() != null
+            && result.monthlyAmount().compareTo(calculateContributionDTO.getMonthlyContributions()) != 0)
                 || (result.effectiveDate() != null && !result.effectiveDate()
                 .equals(calculateContributionDTO.getEffectiveDate()));
     }

--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionService.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionService.java
@@ -76,24 +76,25 @@ public class MaatCalculateContributionService {
 
     public static String getEffectiveDateByNewWorkReason(final CalculateContributionDTO calculateContributionDTO,
                                                          final BigDecimal monthlyContributions,
-                                                         final LocalDate assEffectiveDate) {
+                                                         final LocalDate assessmentEffectiveDate) {
         NewWorkReason newWorkReason = getNewWorkReason(calculateContributionDTO);
+
         if (NewWorkReason.FMA == newWorkReason) {
-            return assEffectiveDate.toString();
-        } else if (NewWorkReason.PAI == newWorkReason) {
+            return assessmentEffectiveDate.toString();
+        }
+
+        if (NewWorkReason.PAI == newWorkReason) {
             if (calculateContributionDTO.getMonthlyContributions() != null
+                && monthlyContributions != null
                 && calculateContributionDTO.getMonthlyContributions().compareTo(monthlyContributions) <= 0) {
                 return calculateContributionDTO.getEffectiveDate().toString();
-            } else {
-                return assEffectiveDate.toString();
             }
-        } else {
-            if (calculateContributionDTO.getEffectiveDate() == null) {
-                return assEffectiveDate.toString();
-            } else {
-                return calculateContributionDTO.getEffectiveDate().toString();
-            }
+
+            return assessmentEffectiveDate.toString();
         }
+
+        return calculateContributionDTO.getEffectiveDate() != null
+            ? calculateContributionDTO.getEffectiveDate().toString() : assessmentEffectiveDate.toString();
     }
 
     public static NewWorkReason getNewWorkReason(final CalculateContributionDTO calculateContributionDTO) {

--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionService.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionService.java
@@ -75,7 +75,7 @@ public class MaatCalculateContributionService {
     }
 
     public static String getEffectiveDateByNewWorkReason(final CalculateContributionDTO calculateContributionDTO,
-                                                         final BigDecimal monthlyContributions,
+                                                         final BigDecimal newMonthlyContributions,
                                                          final LocalDate assessmentEffectiveDate) {
         NewWorkReason newWorkReason = getNewWorkReason(calculateContributionDTO);
 
@@ -85,8 +85,8 @@ public class MaatCalculateContributionService {
 
         if (NewWorkReason.PAI == newWorkReason) {
             if (calculateContributionDTO.getMonthlyContributions() != null
-                && monthlyContributions != null
-                && calculateContributionDTO.getMonthlyContributions().compareTo(monthlyContributions) <= 0) {
+                && newMonthlyContributions != null
+                && newMonthlyContributions.compareTo(calculateContributionDTO.getMonthlyContributions()) <= 0) {
                 return calculateContributionDTO.getEffectiveDate().toString();
             }
 
@@ -227,10 +227,10 @@ public class MaatCalculateContributionService {
                 !Constants.INEL.equals(fullResult)) {
             result = calculateContributions(calculateContributionDTO, contributionResponseDTO);
         } else {
-            LocalDate assEffectiveDate = getEffectiveDate(calculateContributionDTO);
+            LocalDate assessmentEffectiveDate = getEffectiveDate(calculateContributionDTO);
             String effectiveDate =
-                    getEffectiveDateByNewWorkReason(calculateContributionDTO, calculateContributionDTO.getContributionCap(),
-                            assEffectiveDate
+                    getEffectiveDateByNewWorkReason(calculateContributionDTO, BigDecimal.ZERO,
+                            assessmentEffectiveDate
                     );
             result = ContributionResult.builder()
                     .monthlyAmount(BigDecimal.ZERO)
@@ -301,9 +301,9 @@ public class MaatCalculateContributionService {
         log.debug("Request to Calculate Contributions - calculateContributionDTO : {}", calculateContributionDTO);
         log.debug("Request to Calculate Contributions - contributionResponseDTO : {}", contributionResponseDTO);
 
-        LocalDate assEffectiveDate = getEffectiveDate(calculateContributionDTO);
+        LocalDate assessmentEffectiveDate = getEffectiveDate(calculateContributionDTO);
         ContributionCalcParametersDTO contributionCalcParametersDTO =
-                maatCourtDataService.getContributionCalcParameters(DateUtil.getLocalDateString(assEffectiveDate));
+                maatCourtDataService.getContributionCalcParameters(DateUtil.getLocalDateString(assessmentEffectiveDate));
         CrownCourtOutcome crownCourtOutcome =
                 contributionRulesService.getActiveCCOutcome(calculateContributionDTO.getCrownCourtOutcomeList());
 
@@ -323,8 +323,8 @@ public class MaatCalculateContributionService {
         ApiCalculateContributionResponse apiCalculateContributionResponse =
                 calculateContributionService.calculateContribution(apiCalculateContributionRequest);
         String effectiveDate =
-                getEffectiveDateByNewWorkReason(calculateContributionDTO, calculateContributionDTO.getContributionCap(),
-                        assEffectiveDate
+                getEffectiveDateByNewWorkReason(calculateContributionDTO, apiCalculateContributionResponse.getMonthlyContributions(),
+                        assessmentEffectiveDate
                 );
 
         return ContributionResult.builder()

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/builder/ContributionDTOBuilderTest.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/builder/ContributionDTOBuilderTest.java
@@ -35,7 +35,7 @@ class ContributionDTOBuilderTest {
         softly.assertThat(actualContributionDTO.getRepId()).isEqualTo(999);
         softly.assertThat(actualContributionDTO.getEffectiveDate()).isNull();
         softly.assertThat(actualContributionDTO.getContributionCap()).isNull();
-        softly.assertThat(actualContributionDTO.getMonthlyContributions()).isEqualTo(BigDecimal.ZERO);
+        softly.assertThat(actualContributionDTO.getMonthlyContributions()).isNull();
         softly.assertThat(actualContributionDTO.getUpfrontContributions()).isEqualTo(BigDecimal.ZERO);
         softly.assertThat(actualContributionDTO.getDateUpliftApplied()).isNull();
         softly.assertThat(actualContributionDTO.getDateUpliftRemoved()).isNull();

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionServiceTest.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionServiceTest.java
@@ -377,6 +377,24 @@ class MaatCalculateContributionServiceTest {
     }
 
     @Test
+    void givenNewWorkReasonAsPAIAndMonthlyContributionsIsNull_whenGetEffectiveDateByNewWorkReasonIsInvoked_thenContributionEffectiveDateIsReturned() {
+        LocalDate assessmentDate = LocalDate.now();
+        CalculateContributionDTO calculateContributionDTO = CalculateContributionDTO.builder()
+            .assessments(List.of(new ApiAssessment()
+                .withAssessmentType(PASSPORT)
+                .withNewWorkReason(NewWorkReason.PAI)))
+            .effectiveDate(null)
+            .build();
+
+        String actual = MaatCalculateContributionService.getEffectiveDateByNewWorkReason(
+            calculateContributionDTO, BigDecimal.TEN, assessmentDate
+        );
+
+        assertThat(actual)
+            .isEqualTo(assessmentDate.toString());
+    }
+
+    @Test
     void givenAValidAnnualIncomeAfterMagHardship_whenGetAnnualDisposableIncomeIsInvoked_thenAnnualIncomeAfterMagHardshipIsReturned() {
         BigDecimal annualDisposableIncome = BigDecimal.TEN;
         CalculateContributionDTO calculateContributionDTO = CalculateContributionDTO.builder()

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionServiceTest.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionServiceTest.java
@@ -321,26 +321,31 @@ class MaatCalculateContributionServiceTest {
     }
 
     @Test
-    void givenNewWorkReasonAsPAIAndMonthlyContributionsAreSmaller_whenGetEffectiveDateByNewWorkReasonIsInvoked_thenContributionEffectiveDateIsReturned() {
+    void givenNewWorkReasonAsPAIAndCurrentMonthlyContributionsAreSmallerThanNewMonthlyContributions_whenGetEffectiveDateByNewWorkReasonIsInvoked_thenAssessmentEffectiveDateIsReturned() {
         LocalDate effectiveDate = LocalDate.now();
+        LocalDate assessmentDate = LocalDate.now().minusDays(1);
+
+        BigDecimal currentContributions = BigDecimal.TEN;
+        BigDecimal newContributions = BigDecimal.valueOf(100);
+
         CalculateContributionDTO calculateContributionDTO = CalculateContributionDTO.builder()
                 .assessments(List.of(new ApiAssessment()
                         .withAssessmentType(PASSPORT)
                         .withNewWorkReason(NewWorkReason.PAI)))
                 .effectiveDate(effectiveDate)
-                .monthlyContributions(BigDecimal.TEN)
+                .monthlyContributions(currentContributions)
                 .build();
 
         String actual = MaatCalculateContributionService.getEffectiveDateByNewWorkReason(
-                calculateContributionDTO, BigDecimal.valueOf(100), null
+                calculateContributionDTO, newContributions, assessmentDate
         );
 
         assertThat(actual)
-                .isEqualTo(effectiveDate.toString());
+                .isEqualTo(assessmentDate.toString());
     }
 
     @Test
-    void givenNewWorkReasonAsPAIAndMonthlyContributionsAreEqual_whenGetEffectiveDateByNewWorkReasonIsInvoked_thenContributionEffectiveDateIsReturned() {
+    void givenNewWorkReasonAsPAIAndCurrentMonthlyContributionsAreEqualToNewMonthlyContributions_whenGetEffectiveDateByNewWorkReasonIsInvoked_thenContributionEffectiveDateIsReturned() {
         LocalDate effectiveDate = LocalDate.now();
         CalculateContributionDTO calculateContributionDTO = CalculateContributionDTO.builder()
                 .assessments(List.of(new ApiAssessment()
@@ -359,21 +364,27 @@ class MaatCalculateContributionServiceTest {
     }
 
     @Test
-    void givenNewWorkReasonAsPAIAndMonthlyContributionsAreGreater_whenGetEffectiveDateByNewWorkReasonIsInvoked_thenContributionEffectiveDateIsReturned() {
+    void givenNewWorkReasonAsPAIAndCurrentMonthlyContributionsAreGreaterThanNewMonthlyContributions_whenGetEffectiveDateByNewWorkReasonIsInvoked_thenContributionEffectiveDateIsReturned() {
         LocalDate assessmentDate = LocalDate.now();
+        LocalDate effectiveDate = LocalDate.now().plusDays(1);
+
+        BigDecimal currentContributions = BigDecimal.valueOf(12);
+        BigDecimal newContributions = BigDecimal.TEN;
+
         CalculateContributionDTO calculateContributionDTO = CalculateContributionDTO.builder()
                 .assessments(List.of(new ApiAssessment()
                         .withAssessmentType(PASSPORT)
                         .withNewWorkReason(NewWorkReason.PAI)))
-                .monthlyContributions(BigDecimal.valueOf(12))
+                .effectiveDate(effectiveDate)
+                .monthlyContributions(currentContributions)
                 .build();
 
         String actual = MaatCalculateContributionService.getEffectiveDateByNewWorkReason(
-                calculateContributionDTO, BigDecimal.TEN, assessmentDate
+                calculateContributionDTO, newContributions, assessmentDate
         );
 
         assertThat(actual)
-                .isEqualTo(assessmentDate.toString());
+                .isEqualTo(effectiveDate.toString());
     }
 
     @Test

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionServiceTest.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionServiceTest.java
@@ -388,17 +388,43 @@ class MaatCalculateContributionServiceTest {
     }
 
     @Test
-    void givenNewWorkReasonAsPAIAndMonthlyContributionsIsNull_whenGetEffectiveDateByNewWorkReasonIsInvoked_thenContributionEffectiveDateIsReturned() {
+    void givenNewWorkReasonAsPAIAndCurrentMonthlyContributionsIsNull_whenGetEffectiveDateByNewWorkReasonIsInvoked_thenAssessmentEffectiveDateIsReturned() {
         LocalDate assessmentDate = LocalDate.now();
+
+        BigDecimal newContributions = BigDecimal.TEN;
+
         CalculateContributionDTO calculateContributionDTO = CalculateContributionDTO.builder()
             .assessments(List.of(new ApiAssessment()
                 .withAssessmentType(PASSPORT)
                 .withNewWorkReason(NewWorkReason.PAI)))
+            .monthlyContributions(null)
             .effectiveDate(null)
             .build();
 
         String actual = MaatCalculateContributionService.getEffectiveDateByNewWorkReason(
-            calculateContributionDTO, BigDecimal.TEN, assessmentDate
+            calculateContributionDTO, newContributions, assessmentDate
+        );
+
+        assertThat(actual)
+            .isEqualTo(assessmentDate.toString());
+    }
+
+    @Test
+    void givenNewWorkReasonAsPAIAndNewMonthlyContributionsIsNull_whenGetEffectiveDateByNewWorkReasonIsInvoked_thenAssessmentEffectiveDateIsReturned() {
+        LocalDate assessmentDate = LocalDate.now();
+
+        BigDecimal currentContributions = BigDecimal.TEN;
+
+        CalculateContributionDTO calculateContributionDTO = CalculateContributionDTO.builder()
+            .assessments(List.of(new ApiAssessment()
+                .withAssessmentType(PASSPORT)
+                .withNewWorkReason(NewWorkReason.PAI)))
+            .monthlyContributions(currentContributions)
+            .effectiveDate(null)
+            .build();
+
+        String actual = MaatCalculateContributionService.getEffectiveDateByNewWorkReason(
+            calculateContributionDTO, null, assessmentDate
         );
 
         assertThat(actual)


### PR DESCRIPTION
This PR fixes two issues with the effective date, which is calculated as part of creating a contribution. The first of these is a recent null reference exception raised in production when attempting to perform a means assessment with a new work reason of _previous assessment was incorrect_.

![Screenshot 2025-02-07 at 10 54 52](https://github.com/user-attachments/assets/3ec17c04-2fdb-445a-93d6-8c5460e144ef)

This second issues this PR addresses is to pass the correct value when calculating the effective date for the new monthly contributions parameter, aligning the code with the now-migrated calc_contribs stored procedure which this code originates from.

Previously, the value for `monthlyContributions` being passed into the `getEffectiveDateByNewWorkReason` method was set to the contributions cap which was incorrect and was introduced as part of https://github.com/ministryofjustice/laa-crown-court-contribution/pull/89. Instead, the correct _new_ contribution value is passed as the parameter value and the calculation updated to check that _new contributions <= current contributions_ (as per the migrated stored procedure).

Alongside fixing this exception, the `getEffectiveDateByNewWorkReason` method is also refactored to make the method for readable.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1710)
[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1717)