### PR TITLE
Upgrade Spring Boot to 3.4.2

### DIFF
--- a/crown-court-contribution/build.gradle
+++ b/crown-court-contribution/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id "java"
     id "jacoco"
-    id "org.springframework.boot" version "3.3.5"
-    id "io.spring.dependency-management" version "1.1.6"
+    id "org.springframework.boot" version "3.4.2"
+    id "io.spring.dependency-management" version "1.1.7"
     id "org.sonarqube" version "5.1.0.4882"
     id "info.solidsoft.pitest" version "1.15.0"
     id "org.jsonschema2dataclass" version "6.0.0"
@@ -16,11 +16,11 @@ java {
 }
 def versions = [
         pitest                          : "1.17.0",
-        springdocVersion                : "2.6.0",
-        crimeCommonsClasses: "4.2.1",
-        crimeCommonsModsSchemas         : "1.18.1",
+        springdocVersion                : "2.7.0",
+        crimeCommonsClasses             : "4.2.1",
+        crimeCommonsModsSchemas         : "1.26.1",
         springCloudStubRunnerVersion    : "4.1.4",
-        sentryVersion                   : "7.12.1",
+        sentryVersion                   : "7.16.0",
         resilience4jVersion             : "2.2.0",
         postgresqlVersion               : "42.7.2",
         commonsLang3Version             : "3.15.0"

--- a/crown-court-contribution/gradle/wrapper/gradle-wrapper.properties
+++ b/crown-court-contribution/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/controller/CalculateContributionControllerTest.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/controller/CalculateContributionControllerTest.java
@@ -5,10 +5,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.reactive.function.client.WebClientRequestException;
 import uk.gov.justice.laa.crime.contribution.tracing.TraceIdHandler;
@@ -36,10 +36,10 @@ class CalculateContributionControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @MockBean
+    @MockitoBean
     private CalculateContributionService calculateContributionService;
 
-    @MockBean
+    @MockitoBean
     private TraceIdHandler traceIdHandler;
 
     @Test

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/controller/ContributionControllerTest.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/controller/ContributionControllerTest.java
@@ -5,10 +5,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.reactive.function.client.WebClientRequestException;
 import uk.gov.justice.laa.crime.common.model.contribution.ApiMaatCalculateContributionRequest;
@@ -50,16 +50,16 @@ class ContributionControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @MockBean
+    @MockitoBean
     private ContributionService contributionService;
 
-    @MockBean
+    @MockitoBean
     private MaatCalculateContributionService maatCalculateContributionService;
 
-    @MockBean
+    @MockitoBean
     private ContributionRulesService contributionRulesService;
 
-    @MockBean
+    @MockitoBean
     private TraceIdHandler traceIdHandler;
 
     @Test


### PR DESCRIPTION
This PR upgrades Spring Boot from version `3.3.5` to version `3.4.2`, primarily to address security vulnerabilities in `3.3.5` as reported by Snyk but also to bring Spring Boot up to the latest version. The gradle wrapper is also upgraded to version `8.11.1` to allow the project to continue to build ([see a similar PR for the Orchestration Service](https://github.com/ministryofjustice/laa-maat-orchestration/pull/233) which also had to take this step).

This PR also replaces the deprecated testing annotation `@MockBean` with the recommended `@MockitoBean` annotation. Prior to Spring Framework version `6.2.2` this new annotation could only be applied at a field-level and not directly to types, however this has been fixed with `6.2.2`(which is used by Spring Boot `3.4.2`).

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1711)
