### PR TITLE
Fix getEffectiveDateByNewWorkReason to use correct monthly contributions

### DIFF
--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionService.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionService.java
@@ -75,20 +75,20 @@ public class MaatCalculateContributionService {
     }
 
     public static String getEffectiveDateByNewWorkReason(final CalculateContributionDTO calculateContributionDTO,
-                                                         final BigDecimal monthlyContributions,
-                                                         final LocalDate assEffectiveDate) {
+                                                         final BigDecimal newMonthlyContributions,
+                                                         final LocalDate assessmentEffectiveDate) {
         NewWorkReason newWorkReason = getNewWorkReason(calculateContributionDTO);
         if (NewWorkReason.FMA == newWorkReason) {
-            return assEffectiveDate.toString();
+            return assessmentEffectiveDate.toString();
         } else if (NewWorkReason.PAI == newWorkReason) {
-            if (calculateContributionDTO.getMonthlyContributions().compareTo(monthlyContributions) <= 0) {
+            if (newMonthlyContributions.compareTo(calculateContributionDTO.getMonthlyContributions()) <= 0) {
                 return calculateContributionDTO.getEffectiveDate().toString();
             } else {
-                return assEffectiveDate.toString();
+                return assessmentEffectiveDate.toString();
             }
         } else {
             if (calculateContributionDTO.getEffectiveDate() == null) {
-                return assEffectiveDate.toString();
+                return assessmentEffectiveDate.toString();
             } else {
                 return calculateContributionDTO.getEffectiveDate().toString();
             }
@@ -225,10 +225,10 @@ public class MaatCalculateContributionService {
                 !Constants.INEL.equals(fullResult)) {
             result = calculateContributions(calculateContributionDTO, contributionResponseDTO);
         } else {
-            LocalDate assEffectiveDate = getEffectiveDate(calculateContributionDTO);
+            LocalDate assessmentEffectiveDate = getEffectiveDate(calculateContributionDTO);
             String effectiveDate =
-                    getEffectiveDateByNewWorkReason(calculateContributionDTO, calculateContributionDTO.getContributionCap(),
-                            assEffectiveDate
+                    getEffectiveDateByNewWorkReason(calculateContributionDTO, BigDecimal.ZERO,
+                            assessmentEffectiveDate
                     );
             result = ContributionResult.builder()
                     .monthlyAmount(BigDecimal.ZERO)
@@ -298,9 +298,9 @@ public class MaatCalculateContributionService {
         log.debug("Request to Calculate Contributions - calculateContributionDTO : {}", calculateContributionDTO);
         log.debug("Request to Calculate Contributions - contributionResponseDTO : {}", contributionResponseDTO);
 
-        LocalDate assEffectiveDate = getEffectiveDate(calculateContributionDTO);
+        LocalDate assessmentEffectiveDate = getEffectiveDate(calculateContributionDTO);
         ContributionCalcParametersDTO contributionCalcParametersDTO =
-                maatCourtDataService.getContributionCalcParameters(DateUtil.getLocalDateString(assEffectiveDate));
+                maatCourtDataService.getContributionCalcParameters(DateUtil.getLocalDateString(assessmentEffectiveDate));
         CrownCourtOutcome crownCourtOutcome =
                 contributionRulesService.getActiveCCOutcome(calculateContributionDTO.getCrownCourtOutcomeList());
 
@@ -320,8 +320,8 @@ public class MaatCalculateContributionService {
         ApiCalculateContributionResponse apiCalculateContributionResponse =
                 calculateContributionService.calculateContribution(apiCalculateContributionRequest);
         String effectiveDate =
-                getEffectiveDateByNewWorkReason(calculateContributionDTO, calculateContributionDTO.getContributionCap(),
-                        assEffectiveDate
+                getEffectiveDateByNewWorkReason(calculateContributionDTO, apiCalculateContributionResponse.getMonthlyContributions(),
+                        assessmentEffectiveDate
                 );
 
         return ContributionResult.builder()

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionServiceTest.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/MaatCalculateContributionServiceTest.java
@@ -321,26 +321,31 @@ class MaatCalculateContributionServiceTest {
     }
 
     @Test
-    void givenNewWorkReasonAsPAIAndMonthlyContributionsAreSmaller_whenGetEffectiveDateByNewWorkReasonIsInvoked_thenContributionEffectiveDateIsReturned() {
+    void givenNewWorkReasonAsPAIAndCurrentMonthlyContributionsAreSmallerThanNewMonthlyContributions_whenGetEffectiveDateByNewWorkReasonIsInvoked_thenAssessmentEffectiveDateIsReturned() {
         LocalDate effectiveDate = LocalDate.now();
+        LocalDate assessmentDate = LocalDate.now().minusDays(1);
+
+        BigDecimal currentContributions = BigDecimal.TEN;
+        BigDecimal newContributions = BigDecimal.valueOf(100);
+
         CalculateContributionDTO calculateContributionDTO = CalculateContributionDTO.builder()
                 .assessments(List.of(new ApiAssessment()
                         .withAssessmentType(PASSPORT)
                         .withNewWorkReason(NewWorkReason.PAI)))
                 .effectiveDate(effectiveDate)
-                .monthlyContributions(BigDecimal.TEN)
+                .monthlyContributions(currentContributions)
                 .build();
 
         String actual = MaatCalculateContributionService.getEffectiveDateByNewWorkReason(
-                calculateContributionDTO, BigDecimal.valueOf(100), null
+                calculateContributionDTO, newContributions, assessmentDate
         );
 
         assertThat(actual)
-                .isEqualTo(effectiveDate.toString());
+                .isEqualTo(assessmentDate.toString());
     }
 
     @Test
-    void givenNewWorkReasonAsPAIAndMonthlyContributionsAreEqual_whenGetEffectiveDateByNewWorkReasonIsInvoked_thenContributionEffectiveDateIsReturned() {
+    void givenNewWorkReasonAsPAIAndCurrentMonthlyContributionsAreEqualToNewMonthlyContributions_whenGetEffectiveDateByNewWorkReasonIsInvoked_thenContributionEffectiveDateIsReturned() {
         LocalDate effectiveDate = LocalDate.now();
         CalculateContributionDTO calculateContributionDTO = CalculateContributionDTO.builder()
                 .assessments(List.of(new ApiAssessment()
@@ -359,21 +364,27 @@ class MaatCalculateContributionServiceTest {
     }
 
     @Test
-    void givenNewWorkReasonAsPAIAndMonthlyContributionsAreGreater_whenGetEffectiveDateByNewWorkReasonIsInvoked_thenContributionEffectiveDateIsReturned() {
+    void givenNewWorkReasonAsPAIAndCurrentMonthlyContributionsAreGreaterThanNewMonthlyContributions_whenGetEffectiveDateByNewWorkReasonIsInvoked_thenContributionEffectiveDateIsReturned() {
         LocalDate assessmentDate = LocalDate.now();
+        LocalDate effectiveDate = LocalDate.now().plusDays(1);
+
+        BigDecimal currentContributions = BigDecimal.valueOf(12);
+        BigDecimal newContributions = BigDecimal.TEN;
+
         CalculateContributionDTO calculateContributionDTO = CalculateContributionDTO.builder()
                 .assessments(List.of(new ApiAssessment()
                         .withAssessmentType(PASSPORT)
                         .withNewWorkReason(NewWorkReason.PAI)))
-                .monthlyContributions(BigDecimal.valueOf(12))
+                .effectiveDate(effectiveDate)
+                .monthlyContributions(currentContributions)
                 .build();
 
         String actual = MaatCalculateContributionService.getEffectiveDateByNewWorkReason(
-                calculateContributionDTO, BigDecimal.TEN, assessmentDate
+                calculateContributionDTO, newContributions, assessmentDate
         );
 
         assertThat(actual)
-                .isEqualTo(assessmentDate.toString());
+                .isEqualTo(effectiveDate.toString());
     }
 
     @Test


### PR DESCRIPTION
This PR fixes the `getEffectiveDateByNewWorkReason` method of the _MaatCalculateContributionService_ to use the correct value for the _new_ monthly contributions, as was the case in the now-migrated `calc_contribs` stored procedure which this code originates from.

Previously, the `monthlyContributions` value being passed into this method was set to the contributions cap which was incorrect and was introduced in [PR #89](https://github.com/ministryofjustice/laa-crown-court-contribution/pull/89).

This commit also refactors some variable naming and makes the tests around `getEffectiveDateByNewWorkReason` easier to understand.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1717)