### PR TITLE
Use active contribution when checking contribution equivalence

### DIFF
--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/CompareContributionService.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/CompareContributionService.java
@@ -33,14 +33,14 @@ public class CompareContributionService {
 
         List<Contribution> contributions = maatCourtDataService.findContribution(repId, false);
         log.debug("shouldCreateContribution.contributions--" + contributions);
-        List<Contribution> activeContribution =
-                Optional.ofNullable(contributions)
-                        .orElse(Collections.emptyList()).stream()
-                        .filter(isActiveContribution(repId)).toList();
+        Optional<Contribution> activeContribution =
+            Optional.ofNullable(contributions)
+                .orElse(Collections.emptyList()).stream()
+                .filter(isActiveContribution(repId))
+                .findFirst();
 
-
-        if (!activeContribution.isEmpty()
-                && areContributionRecordsIdentical(contributionResult, contributions.get(0))
+        if (activeContribution.isPresent()
+                && areContributionRecordsIdentical(contributionResult, activeContribution.get())
                 && !(contributionService.hasMessageOutcomeChanged(magsCourtOutcome, repOrderDTO)
                     || CaseType.APPEAL_CC.getCaseTypeString().equals(repOrderDTO.getCatyCaseType()))) {
             log.info("Contributions should not be created");

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/data/builder/TestModelDataBuilder.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/data/builder/TestModelDataBuilder.java
@@ -273,6 +273,22 @@ public class TestModelDataBuilder {
                 .build();
     }
 
+    public static Contribution buildInactiveContributionForCompareContributionService() {
+        return Contribution.builder()
+            .id(124)
+            .applicantId(123)
+            .repId(123)
+            .replacedDate(LocalDate.now().minusDays(1))
+            .calcDate(LocalDate.now().minusDays(1))
+            .contributionCap(BigDecimal.valueOf(250))
+            .monthlyContributions(BigDecimal.valueOf(300))
+            .upfrontContributions(BigDecimal.valueOf(250))
+            .effectiveDate(LocalDate.now())
+            .userCreated("test")
+            .active("N")
+            .build();
+    }
+
     public static ApiMaatCalculateContributionRequest buildAppealContributionRequest() {
         return new ApiMaatCalculateContributionRequest()
                 .withApplicantId(999)


### PR DESCRIPTION
This PR fixes the `shouldCreateContribution` method of the _CompareContributionService_ to pass the _active_ contribution to be checked against the newly calculated contribution amount when determining whether to create a new contribution record for an application.

This check used to be in place but was changed in PR https://github.com/ministryofjustice/laa-crown-court-contribution/pull/185 as part of general refactoring and was not caught as part of that work as there were no tests covering this (all tests used a single contribution, which meant that the issue was not raised). Tests have been added as part of this PR to help prevent any further regression.

This issue came to light after creating means assessments against an application in MAAT resulted in contributions being created, even when the contributions were identical; the reason for this was because the first contribution was always being used for the comparison, even when it had been replaced.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1707)