### PR TITLE
LCAM 1744 Simplify Contribution Comparison Logic

### DIFF
--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/CompareContributionService.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/CompareContributionService.java
@@ -27,10 +27,6 @@ public class CompareContributionService {
     @Transactional
     public boolean shouldCreateContribution(CalculateContributionDTO calculateContributionDTO, ContributionResult contributionResult) {
         int repId = calculateContributionDTO.getRepId();
-        RepOrderDTO repOrderDTO = calculateContributionDTO.getRepOrderDTO();
-        MagCourtOutcome magsCourtOutcome = calculateContributionDTO.getMagCourtOutcome() == null ? null
-                : calculateContributionDTO.getMagCourtOutcome();
-
         List<Contribution> contributions = maatCourtDataService.findContribution(repId, false);
         log.debug("shouldCreateContribution.contributions--" + contributions);
         Optional<Contribution> activeContribution =
@@ -41,8 +37,8 @@ public class CompareContributionService {
 
         if (activeContribution.isPresent()
                 && areContributionRecordsIdentical(contributionResult, activeContribution.get())
-                && !(hasMagsCourtOutcomeChanged(magsCourtOutcome, repOrderDTO)
-                    || CaseType.APPEAL_CC.getCaseTypeString().equals(repOrderDTO.getCatyCaseType()))) {
+                && isMagsCourtOutcomeUnchanged(calculateContributionDTO.getMagCourtOutcome(),
+                                               calculateContributionDTO.getRepOrderDTO())) {
             log.info("Contributions should not be created");
             return false;
         }
@@ -50,10 +46,10 @@ public class CompareContributionService {
         return true;
     }
 
-    private boolean hasMagsCourtOutcomeChanged(MagCourtOutcome magsCourtOutcome, RepOrderDTO repOrderDTO) {
-        if (repOrderDTO == null) return false;
+    private boolean isMagsCourtOutcomeUnchanged(MagCourtOutcome magsCourtOutcome, RepOrderDTO repOrderDTO) {
+        if (repOrderDTO == null) return true;
 
-        return !Objects.equals(magsCourtOutcome, MagCourtOutcome.getFrom(repOrderDTO.getMagsOutcome()));
+        return Objects.equals(magsCourtOutcome, MagCourtOutcome.getFrom(repOrderDTO.getMagsOutcome()));
     }
 
     private static boolean areContributionRecordsIdentical(ContributionResult contributionResult,

--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/CompareContributionService.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/CompareContributionService.java
@@ -9,9 +9,11 @@ import uk.gov.justice.laa.crime.contribution.dto.RepOrderDTO;
 import uk.gov.justice.laa.crime.contribution.model.Contribution;
 import uk.gov.justice.laa.crime.contribution.model.ContributionResult;
 import uk.gov.justice.laa.crime.enums.CaseType;
+import uk.gov.justice.laa.crime.enums.MagCourtOutcome;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -22,14 +24,12 @@ public class CompareContributionService {
 
     private final MaatCourtDataService maatCourtDataService;
 
-    private final ContributionService contributionService;
-
     @Transactional
     public boolean shouldCreateContribution(CalculateContributionDTO calculateContributionDTO, ContributionResult contributionResult) {
         int repId = calculateContributionDTO.getRepId();
         RepOrderDTO repOrderDTO = calculateContributionDTO.getRepOrderDTO();
-        String magsCourtOutcome = calculateContributionDTO.getMagCourtOutcome() == null ? null
-                : calculateContributionDTO.getMagCourtOutcome().getOutcome();
+        MagCourtOutcome magsCourtOutcome = calculateContributionDTO.getMagCourtOutcome() == null ? null
+                : calculateContributionDTO.getMagCourtOutcome();
 
         List<Contribution> contributions = maatCourtDataService.findContribution(repId, false);
         log.debug("shouldCreateContribution.contributions--" + contributions);
@@ -41,13 +41,19 @@ public class CompareContributionService {
 
         if (activeContribution.isPresent()
                 && areContributionRecordsIdentical(contributionResult, activeContribution.get())
-                && !(contributionService.hasMessageOutcomeChanged(magsCourtOutcome, repOrderDTO)
+                && !(hasMagsCourtOutcomeChanged(magsCourtOutcome, repOrderDTO)
                     || CaseType.APPEAL_CC.getCaseTypeString().equals(repOrderDTO.getCatyCaseType()))) {
             log.info("Contributions should not be created");
             return false;
         }
         log.info("Contributions should be created");
         return true;
+    }
+
+    private boolean hasMagsCourtOutcomeChanged(MagCourtOutcome magsCourtOutcome, RepOrderDTO repOrderDTO) {
+        if (repOrderDTO == null) return false;
+
+        return !Objects.equals(magsCourtOutcome, MagCourtOutcome.getFrom(repOrderDTO.getMagsOutcome()));
     }
 
     private static boolean areContributionRecordsIdentical(ContributionResult contributionResult,

--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/ContributionService.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/service/ContributionService.java
@@ -161,14 +161,6 @@ public class ContributionService {
                 && InitAssessmentResult.PASS.getResult().equals(initialAssessmentResult);
     }
 
-    public boolean hasMessageOutcomeChanged(String msgOutcome, RepOrderDTO repOrderDTO) {
-        if (null != repOrderDTO) {
-            String messageOutcome = Optional.ofNullable(repOrderDTO.getMagsOutcome()).orElse("na");
-            return !messageOutcome.equals(msgOutcome);
-        }
-        return false;
-    }
-
     public boolean hasCCOutcomeChanged(final int repId) {
         List<RepOrderCCOutcomeDTO> repOrderCCOutcomeList = maatCourtDataService.getRepOrderCCOutcomeByRepId(repId);
         if (CollectionUtils.isNotEmpty(repOrderCCOutcomeList)) {

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/CompareContributionServiceTest.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/CompareContributionServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.laa.crime.contribution.service;
 
-import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -19,6 +18,7 @@ import uk.gov.justice.laa.crime.enums.MagCourtOutcome;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.*;
@@ -32,14 +32,11 @@ class CompareContributionServiceTest {
     @Mock
     private MaatCourtDataService maatCourtDataService;
 
-    @Mock
-    private ContributionService contributionService;
-
     @Test
     void givenNoPreviousContribution_whenShouldCreateContributionIsInvoked_thenReturnTrue() {
         CalculateContributionDTO calculateContributionDTO =
                 TestModelDataBuilder.getContributionDTOForCompareContributionService(
-                        CaseType.APPEAL_CC.getCaseTypeString(),
+                        CaseType.EITHER_WAY.getCaseTypeString(),
                         null,
                         null,
                         null,
@@ -73,17 +70,17 @@ class CompareContributionServiceTest {
                 upfrontContributions,
                 monthlyContributions,
                 effectiveDate,
-                MagCourtOutcome.APPEAL_TO_CC
+                MagCourtOutcome.COMMITTED
             );
         ContributionResult contributionResult = ContributionResult.builder()
             .totalAnnualDisposableIncome(BigDecimal.valueOf(16000.00))
-            .monthlyAmount(BigDecimal.valueOf(300.00))
-            .upfrontAmount(BigDecimal.valueOf(250.00))
-            .contributionCap(BigDecimal.valueOf(250.00))
+            .monthlyAmount(monthlyContributions)
+            .upfrontAmount(upfrontContributions)
+            .contributionCap(contributionCap)
             .totalMonths(5)
             .isUplift(false)
             .basedOn("Means")
-            .effectiveDate(LocalDate.now())
+            .effectiveDate(effectiveDate)
             .build();
 
         when(maatCourtDataService.findContribution(anyInt(), anyBoolean()))
@@ -106,7 +103,7 @@ class CompareContributionServiceTest {
                         BigDecimal.valueOf(250),
                         BigDecimal.valueOf(250),
                         LocalDate.now(),
-                        MagCourtOutcome.APPEAL_TO_CC
+                        MagCourtOutcome.COMMITTED
                 );
         ContributionResult contributionResult = ContributionResult.builder()
                 .totalAnnualDisposableIncome(BigDecimal.valueOf(16000.00))
@@ -132,7 +129,31 @@ class CompareContributionServiceTest {
     }
 
     @Test
-    void givenMultipleContributionsExistAndActiveContributionIsIdentical_whenShouldCreateContributionIsInvoked_thenReturnFalse() {
+    void givenActiveIdenticalContributionAndMagsOutcomeChanged_whenShouldCreateContributionIsInvoked_thenReturnTrue() {
+        CalculateContributionDTO calculateContributionDTO =
+                TestModelDataBuilder.getContributionDTOForCompareContributionService(
+                        CaseType.EITHER_WAY.getCaseTypeString(),
+                        BigDecimal.valueOf(250),
+                        BigDecimal.valueOf(250),
+                        BigDecimal.valueOf(250),
+                        LocalDate.now(),
+                        MagCourtOutcome.COMMITTED_FOR_TRIAL
+                );
+        ContributionResult contributionResult = TestModelDataBuilder.getContributionResult();
+
+        when(maatCourtDataService.findContribution(anyInt(), anyBoolean()))
+                .thenReturn(List.of(
+                                TestModelDataBuilder.buildContributionForCompareContributionService()
+                        )
+                );
+
+        boolean result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void givenMultipleContributionsExistActiveContributionIsIdenticalAndMagsOutcomeUnchanged_whenShouldCreateContributionIsInvoked_thenReturnFalse() {
         CalculateContributionDTO calculateContributionDTO =
             TestModelDataBuilder.getContributionDTOForCompareContributionService(
                 CaseType.COMMITAL.getCaseTypeString(),
@@ -140,8 +161,9 @@ class CompareContributionServiceTest {
                 BigDecimal.valueOf(250),
                 BigDecimal.valueOf(250),
                 LocalDate.now(),
-                MagCourtOutcome.APPEAL_TO_CC
+                MagCourtOutcome.COMMITTED
             );
+        calculateContributionDTO.getRepOrderDTO().setMagsOutcome(MagCourtOutcome.COMMITTED.getOutcome());
         ContributionResult contributionResult = ContributionResult.builder()
             .totalAnnualDisposableIncome(BigDecimal.valueOf(16000.00))
             .monthlyAmount(BigDecimal.valueOf(250.00))
@@ -165,110 +187,32 @@ class CompareContributionServiceTest {
         assertThat(result).isFalse();
     }
 
-    @Test
-    void givenActiveIdenticalContributionAndMagsOutcomeChanged_whenShouldCreateContributionIsInvoked_thenReturnTrue() {
-        CalculateContributionDTO calculateContributionDTO =
-                TestModelDataBuilder.getContributionDTOForCompareContributionService(
-                        CaseType.COMMITAL.getCaseTypeString(),
-                        BigDecimal.valueOf(250),
-                        BigDecimal.valueOf(250),
-                        BigDecimal.valueOf(250),
-                        LocalDate.now(),
-                        MagCourtOutcome.APPEAL_TO_CC
-                );
-        ContributionResult contributionResult = TestModelDataBuilder.getContributionResult();
-
-        when(maatCourtDataService.findContribution(anyInt(), anyBoolean()))
-                .thenReturn(List.of(
-                                TestModelDataBuilder.buildContributionForCompareContributionService()
-                        )
-                );
-        when(contributionService.hasMessageOutcomeChanged(anyString(), any()))
-                .thenReturn(true);
-
-        boolean result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
-
-        assertThat(result).isTrue();
-    }
-
-    @Test
-    void givenActiveIdenticalContributionWithCaseTypeAppealCC_whenShouldCreateContributionIsInvoked_thenReturnTrue() {
-        CalculateContributionDTO calculateContributionDTO =
-                TestModelDataBuilder.getContributionDTOForCompareContributionService(
-                        CaseType.APPEAL_CC.getCaseTypeString(),
-                        BigDecimal.valueOf(250),
-                        BigDecimal.valueOf(250),
-                        BigDecimal.valueOf(250),
-                        LocalDate.now(),
-                        MagCourtOutcome.APPEAL_TO_CC
-                );
-        ContributionResult contributionResult = TestModelDataBuilder.getContributionResult();
-
-        when(maatCourtDataService.findContribution(anyInt(), anyBoolean()))
-                .thenReturn(List.of(
-                                TestModelDataBuilder.buildContributionForCompareContributionService()
-                        )
-                );
-        when(contributionService.hasMessageOutcomeChanged(anyString(), any()))
-                .thenReturn(false);
-
-        boolean result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
-
-        assertThat(result).isTrue();
-    }
-
-    @Test
-    void givenActiveIdenticalContributionNonAppealCCWithoutMagsOutcomeChange_whenShouldCreateContributionIsInvoked_thenReturnFalse() {
-        CalculateContributionDTO calculateContributionDTO =
-                TestModelDataBuilder.getContributionDTOForCompareContributionService(
-                        CaseType.COMMITAL.getCaseTypeString(),
-                        BigDecimal.valueOf(250),
-                        BigDecimal.valueOf(250),
-                        BigDecimal.valueOf(250),
-                        LocalDate.now(),
-                        MagCourtOutcome.APPEAL_TO_CC
-                );
-        ContributionResult contributionResult = TestModelDataBuilder.getContributionResult();
-
-        when(maatCourtDataService.findContribution(anyInt(), anyBoolean()))
-                .thenReturn(List.of(
-                                TestModelDataBuilder.buildContributionForCompareContributionService()
-                        )
-                );
-        when(contributionService.hasMessageOutcomeChanged(anyString(), any()))
-                .thenReturn(false);
-
-        boolean result = compareContributionService.shouldCreateContribution(calculateContributionDTO, contributionResult);
-
-        assertThat(result).isFalse();
-    }
-
     private static Stream<Arguments> getActiveNonIdenticalContribution() {
         return Stream.of(
-            Arguments.of(
-                BigDecimal.valueOf(500),
-                BigDecimal.valueOf(250),
-                BigDecimal.valueOf(300),
-                LocalDate.now()
-            ),
-            Arguments.of(
-                BigDecimal.valueOf(250),
-                BigDecimal.valueOf(500),
-                BigDecimal.valueOf(300),
-                LocalDate.now()
-            ),
-            Arguments.of(
-                BigDecimal.valueOf(250),
-                BigDecimal.valueOf(250),
-                BigDecimal.valueOf(500),
-                LocalDate.now()
-            ),
-            Arguments.of(
-                BigDecimal.valueOf(250),
-                BigDecimal.valueOf(250),
-                BigDecimal.valueOf(300),
-                LocalDate.now().minusDays(1)
-            )
+                Arguments.of(
+                        BigDecimal.valueOf(500),
+                        BigDecimal.valueOf(250),
+                        BigDecimal.valueOf(300),
+                        LocalDate.now()
+                ),
+                Arguments.of(
+                        BigDecimal.valueOf(250),
+                        BigDecimal.valueOf(500),
+                        BigDecimal.valueOf(300),
+                        LocalDate.now()
+                ),
+                Arguments.of(
+                        BigDecimal.valueOf(250),
+                        BigDecimal.valueOf(250),
+                        BigDecimal.valueOf(500),
+                        LocalDate.now()
+                ),
+                Arguments.of(
+                        BigDecimal.valueOf(250),
+                        BigDecimal.valueOf(250),
+                        BigDecimal.valueOf(300),
+                        LocalDate.now().minusDays(1)
+                )
         );
     }
 }

--- a/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/ContributionServiceTest.java
+++ b/crown-court-contribution/src/test/java/uk/gov/justice/laa/crime/contribution/service/ContributionServiceTest.java
@@ -645,45 +645,6 @@ class ContributionServiceTest {
     }
 
     @Test
-    void givenInvalidRepId_whenHasMessageOutcomeChangedIsInvoked_thenFalseIsReturn() {
-        boolean hasMsgOutcomeChanged = contributionService.hasMessageOutcomeChanged("outcome", null);
-
-        assertThat(hasMsgOutcomeChanged)
-                .isFalse();
-
-    }
-
-    @Test
-    void givenValidRepIdAndOutcomeIsNotMatch_whenHasMessageOutcomeChangedIsInvoked_thenFalseIsReturn() {
-        boolean hasMsgOutcomeChanged = contributionService.hasMessageOutcomeChanged("outcome", getRepOrderDTO(REP_ID));
-
-        assertThat(hasMsgOutcomeChanged)
-                .isFalse();
-
-    }
-
-    @Test
-    void givenValidRepIdAndOutcomeIsNull_whenHasMessageOutcomeChangedIsInvoked_thenTrueIsReturn() {
-        RepOrderDTO repOrderDTO = getRepOrderDTO(REP_ID);
-        repOrderDTO.setMagsOutcome(null);
-        boolean hasMsgOutcomeChanged = contributionService.hasMessageOutcomeChanged("outcome", repOrderDTO);
-
-        assertThat(hasMsgOutcomeChanged)
-                .isTrue();
-
-    }
-
-    @Test
-    void givenValidRepId_whenHasMessageOutcomeChangedIsInvoked_thenTrueIsReturn() {
-        boolean hasMsgOutcomeChanged =
-                contributionService.hasMessageOutcomeChanged("outcomeMessage", getRepOrderDTO(REP_ID));
-
-        assertThat(hasMsgOutcomeChanged)
-                .isTrue();
-
-    }
-
-    @Test
     void givenValidRepIdAndNullCCOutcome_whenHasCCOutcomeChangedIsInvoked_thenFalseIsReturn() {
         when(maatCourtDataService.getRepOrderCCOutcomeByRepId(REP_ID))
                 .thenReturn(null);


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-1744)

- Moved and renamed `hasMessageOutcomeChanged` to `compareContributionService` and simplified it's logic.
- Removed the check for APPEAL_CC case type from `shouldCreateContribution` and simplified the logic.
- Removed unit tests for `hasMessageOutcomeChanged` now it has been made private.
- Updated unit tests for `shouldCreateContribution` based on changes made to logic.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.