### PR TITLE
Fix security vulnerability in spring-security-crypto

### DIFF
--- a/crown-court-contribution/build.gradle
+++ b/crown-court-contribution/build.gradle
@@ -23,7 +23,9 @@ def versions = [
         sentryVersion                   : "7.16.0",
         resilience4jVersion             : "2.2.0",
         postgresqlVersion               : "42.7.2",
-        commonsLang3Version             : "3.15.0"
+        commonsLang3Version             : "3.15.0",
+        oauth2ResourceServer            : "3.4.1",
+        securityCrypto                  : "6.4.4"
 ]
 
 configurations {
@@ -51,7 +53,8 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-oauth2-client"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     implementation "org.springframework.boot:spring-boot-starter-validation"
-    implementation "org.springframework.boot:spring-boot-starter-oauth2-resource-server"
+    implementation "org.springframework.boot:spring-boot-starter-oauth2-resource-server:$versions.oauth2ResourceServer"
+    implementation "org.springframework.security:spring-security-crypto:$versions.securityCrypto"
     implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:$versions.springdocVersion"
     implementation "org.apache.commons:commons-lang3:$versions.commonsLang3Version"
     implementation "io.github.resilience4j:resilience4j-spring-boot3:$versions.resilience4jVersion"


### PR DESCRIPTION
This PR fixes the [recently published security vulnerability] (https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-9486467) in `spring-security-crypto` by forcibly bumping the dependency up to version `6.4.4`.

Spring Boot version `3.4.4` does patch `spring-security-crypto` to this same version, but in order to upgrade Spring Boot, Crime Commons modules also need to be upgraded at the same time, which has more potential to cause problems elsewhere. In that context and to ensure that the Orchestration Service can be as quickly fixed to allow deployments once again, this temporary fix is made in this PR until such time as Spring Boot is upgraded to `3.4.4`.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1788)