### PR TITLE
[LCAM-1814] Update the hardshipWebClient config to use the hardship registrationId

### DIFF
--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/config/WebClientsConfiguration.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/config/WebClientsConfiguration.java
@@ -94,7 +94,7 @@ public class WebClientsConfiguration {
 
         ServletOAuth2AuthorizedClientExchangeFilterFunction oauthFilter =
                 new ServletOAuth2AuthorizedClientExchangeFilterFunction(clientRegistrations, authorizedClients);
-        oauthFilter.setDefaultClientRegistrationId(servicesConfiguration.getMaatApi().getRegistrationId());
+        oauthFilter.setDefaultClientRegistrationId(servicesConfiguration.getHardshipApi().getRegistrationId());
 
         Resilience4jRetryFilter retryFilter =
                 new Resilience4jRetryFilter(retryRegistry, HARDSHIP_SERVICE_WEB_CLIENT_NAME);


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1814)

Updated the hardshipWebClient config to use the hardship registrationId. There was an issue with this service communicating with the Hardship service. The registrationId was using the MAAT API one, so this should fix it. 

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.