### PR TITLE
LCAM-1830: Handle HTTP 404 Responses as Non-Errors in C3 WebClient

### DIFF
--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/filter/WebClientFilters.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/filter/WebClientFilters.java
@@ -29,7 +29,7 @@ public class WebClientFilters {
             clientRequest.headers()
                     .forEach((name, values) -> {
                         if (!name.equals(HttpHeaders.AUTHORIZATION)) {
-                            values.forEach(value -> log.info("{}={}", name, value));
+                            values.forEach(value -> log.debug("{}={}", name, value));
                         }
                     });
             return next.exchange(clientRequest);

--- a/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/filter/WebClientFilters.java
+++ b/crown-court-contribution/src/main/java/uk/gov/justice/laa/crime/contribution/filter/WebClientFilters.java
@@ -14,10 +14,10 @@ public class WebClientFilters {
 
     public static ExchangeFilterFunction logResponse() {
         return ExchangeFilterFunction.ofResponseProcessor(clientResponse -> {
-            if (clientResponse.statusCode().is4xxClientError() || clientResponse.statusCode().is5xxServerError()) {
-                log.error("❌  Response status: {}", clientResponse.statusCode());
-            } else if (clientResponse.statusCode().is2xxSuccessful()) {
+            if (clientResponse.statusCode().is2xxSuccessful() || clientResponse.statusCode().isSameCodeAs(HttpStatus.NOT_FOUND)) {
                 log.info("✅ Response status: {}", clientResponse.statusCode());
+            } else if (clientResponse.statusCode().is4xxClientError() || clientResponse.statusCode().is5xxServerError()) {
+                log.error("❌  Response status: {}", clientResponse.statusCode());
             }
             return Mono.just(clientResponse);
         });


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1830)

This PR tightens up our WebClient logging to reduce noise and correctly classify 404s:

- Treat 404 as a successful response
  - The `logResponse` filter now logs `HttpStatus.NOT_FOUND` at `INFO` level alongside 2xx codes.
- Move header values to DEBUG
  - The `logRequestHeaders` filter still logs the request line at `INFO`, but all header values (except Authorization) are now logged at `DEBUG` level only.

Together these changes ensure that expected “not found” responses and routine headers don’t flood our error logs.