### PR TITLE
LASB-4086 - Disable prod ingress and add ModSecurity to non-prod

### DIFF
--- a/helm_deploy/laa-crown-court-contribution/values-dev.yaml
+++ b/helm_deploy/laa-crown-court-contribution/values-dev.yaml
@@ -50,12 +50,17 @@ ingress:
     external-dns.alpha.kubernetes.io/set-identifier: "laa-crown-court-contribution-laa-crown-court-contribution-dev-green"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "300"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecAuditEngine On
+      SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apps-team,tag:namespace=laa-crown-court-contribution-dev"
   externalAnnotations: {}
   hosts:
     - host: laa-crown-court-contribution-dev.apps.live.cloud-platform.service.justice.gov.uk
       paths: ["/"]
   tls: []
-  className: default
+  className: modsec-non-prod
 
 autoscaling:
   enabled: false

--- a/helm_deploy/laa-crown-court-contribution/values-prod.yaml
+++ b/helm_deploy/laa-crown-court-contribution/values-prod.yaml
@@ -44,18 +44,7 @@ service:
   targetPort: 8089
 
 ingress:
-  enabled: true
-  annotations:
-    external-dns.alpha.kubernetes.io/aws-weight: "100"
-    external-dns.alpha.kubernetes.io/set-identifier: "laa-crown-court-contribution-laa-crown-court-contribution-prod-green"
-    nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-max-age: "300"
-  externalAnnotations: {}
-  hosts:
-    - host: laa-crown-court-contribution-prod.apps.live.cloud-platform.service.justice.gov.uk
-      paths: ["/open-api/"]
-  tls: []
-  className: default
+  enabled: false
 
 autoscaling:
   enabled: false

--- a/helm_deploy/laa-crown-court-contribution/values-test.yaml
+++ b/helm_deploy/laa-crown-court-contribution/values-test.yaml
@@ -50,12 +50,17 @@ ingress:
     external-dns.alpha.kubernetes.io/set-identifier: "laa-crown-court-contribution-laa-crown-court-contribution-test-green"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "300"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecAuditEngine On
+      SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apps-team,tag:namespace=laa-crown-court-contribution-test"
   externalAnnotations: {}
   hosts:
     - host: laa-crown-court-contribution-test.apps.live.cloud-platform.service.justice.gov.uk
       paths: ["/"]
   tls: []
-  className: default
+  className: modsec-non-prod
 
 autoscaling:
   enabled: false

--- a/helm_deploy/laa-crown-court-contribution/values-uat.yaml
+++ b/helm_deploy/laa-crown-court-contribution/values-uat.yaml
@@ -50,12 +50,17 @@ ingress:
     external-dns.alpha.kubernetes.io/set-identifier: "laa-crown-court-contribution-laa-crown-court-contribution-uat-green"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "300"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecAuditEngine On
+      SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apps-team,tag:namespace=laa-crown-court-contribution-uat"
   externalAnnotations: {}
   hosts:
     - host: laa-crown-court-contribution-uat.apps.live.cloud-platform.service.justice.gov.uk
       paths: [ "/" ]
   tls: []
-  className: default
+  className: modsec-non-prod
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4086)

Disabled the ingress in prod and added ModSecurity to non-prod.

Please note, with the ModSecurity I have set it to DetectionOnly - This means requests won't be blocked, but will still be logged. This way we can monitor for a while and ensure it's not causing any false-positives before we start blocking requests.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.