### PR TITLE
Add IP allowlist to Contributions Service

### DIFF
--- a/helm_deploy/laa-crown-court-contribution/templates/_helpers.tpl
+++ b/helm_deploy/laa-crown-court-contribution/templates/_helpers.tpl
@@ -31,6 +31,16 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Create ingress configuration
+*/}}
+{{- define "laa-crown-court-contribution.ingress" -}}
+{{- $internalAllowlistSourceRange := (lookup "v1" "Secret" .Release.Namespace "ingress-internal-allowlist-source-range").data.INTERNAL_ALLOWLIST_SOURCE_RANGE | b64dec }}
+{{- if $internalAllowlistSourceRange }}
+  nginx.ingress.kubernetes.io/whitelist-source-range: {{ $internalAllowlistSourceRange }}
+{{- end }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "laa-crown-court-contribution.labels" -}}

--- a/helm_deploy/laa-crown-court-contribution/templates/ingress.yaml
+++ b/helm_deploy/laa-crown-court-contribution/templates/ingress.yaml
@@ -17,10 +17,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- if .Values.ingress.internal_whitelist_source_range }}
-    nginx.ingress.kubernetes.io/whitelist-source-range: {{ $.Values.ingress.internal_whitelist_source_range }}
-    external-dns.alpha.kubernetes.io/set-identifier: {{ $fullName }}-{{ $.Values.ingress.environmentName}}-green
-  {{- end }}
+  {{- include "laa-crown-court-contribution.ingress" . | nindent 2 }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   {{- if .Values.ingress.tls }}


### PR DESCRIPTION
This PR adds an IP allowlist to the Contributions Service for internal ingress and restricted to non-production environments.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4145)